### PR TITLE
Allow config.h to be included in multiple files.

### DIFF
--- a/OMX-27-firmware/config.cpp
+++ b/OMX-27-firmware/config.cpp
@@ -1,0 +1,75 @@
+#include "config.h"
+
+const OMXMode DEFAULT_MODE = MODE_MIDI;
+const uint8_t EEPROM_VERSION = 8;
+
+// DEFINE CC NUMBERS FOR POTS // CCS mapped to Organelle Defaults
+const int CC1 = 21;
+const int CC2 = 22; 
+const int CC3 = 23;
+const int CC4 = 24;
+const int CC5 = 7;		// change to 25 for EYESY Knob 5
+
+const int CC_AUX = 25; // Mother mode - AUX key
+const int CC_OM1 = 26; // Mother mode - enc switch 
+const int CC_OM2 = 28; // Mother mode - enc turn
+
+const int LED_BRIGHTNESS = 50;
+
+// DONT CHANGE ANYTHING BELOW HERE
+
+const int LED_PIN  = 14;
+const int LED_COUNT = 27;
+
+#if DEV			
+	const int analogPins[] = {23,22,21,20,16};	// DEV/beta boards
+#elif MIDIONLY
+	const int analogPins[] = {23,22,21,20,16};  // on MIDI only boards - {23,A10,21,20,16} on Bodged MIDI boards
+#else
+	const int analogPins[] = {A10,22,21,20,16}; // on 1.0
+#endif
+
+int pots[NUM_CC_POTS] = {CC1,CC2,CC3,CC4,CC5};			// the MIDI CC (continuous controller) for each analog input
+
+const int gridh = 32;
+const int gridw = 128;
+const int PPQ = 96;
+
+const char* modes[] = {"MI","S1","S2","OM"};
+const char* infoDialogText[] = {"COPIED","PASTED","CLEARED","RESET","FWD >>","<< REV","SAVED","SAVE?"};
+
+float multValues[] = {.25, .5, 1, 2, 4, 8, 16};
+const char* mdivs[] = {"1/64", "1/32", "1/16", "1/8", "1/4", "1/2", "W"};
+
+InfoDialogs infoDialog[NUM_DIALOGS] = {
+  {"COPIED", false},
+  {"PASTED", false},
+  {"CLEARED", false},
+  {"RESET", false},
+  {"FWD >>", false},
+  {"<< REV", false},
+  {"SAVED", false},
+  {"SAVE?", false}
+};
+
+// KEY SWITCH ROWS/COLS
+
+// Map the keys
+char keys[ROWS][COLS] = {
+  {0, 1, 2, 3, 4, 5},
+  {6, 7, 8, 9, 10,26},
+  {11,12,13,14,15,24},
+  {16,17,18,19,20,25},
+  {22,23,21}
+  };
+byte rowPins[ROWS] = {6, 4, 3, 5, 2}; // row pins for key switches
+byte colPins[COLS] = {7, 8, 10, 9, 15, 17}; // column pins for key switches
+
+// KEYBOARD MIDI NOTE LAYOUT
+const int notes[] = {0,
+     61,63,   66,68,70,   73,75,   78,80,82,
+59,60,62,64,65,67,69,71,72,74,76,77,79,81,83,84};
+
+const int steps[] = {0,
+     1,2,   3,4,5,   6,7,   8,9,10,
+11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26};

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -1,4 +1,8 @@
+#pragma once
 //const int OMX_VERSION = 1.3.0;
+
+#include <Arduino.h>
+#include <stdint.h>
 
 enum OMXMode
 {
@@ -10,10 +14,10 @@ enum OMXMode
      NUM_OMX_MODES
 };
 
-const OMXMode DEFAULT_MODE = MODE_MIDI;
+extern const OMXMode DEFAULT_MODE;
 
 // Increment this when data layout in EEPROM changes. May need to write version upgrade readers when this changes.
-const uint8_t EEPROM_VERSION = 8;
+extern const uint8_t EEPROM_VERSION;
 
 #define EEPROM_HEADER_ADDRESS	          0
 #define EEPROM_HEADER_SIZE		     32
@@ -24,42 +28,36 @@ const uint8_t EEPROM_VERSION = 8;
 // next address 1104 (was 1096 before clock)
 
 // DEFINE CC NUMBERS FOR POTS // CCS mapped to Organelle Defaults
-const int CC1 = 21;
-const int CC2 = 22; 
-const int CC3 = 23;
-const int CC4 = 24;
-const int CC5 = 7;		// change to 25 for EYESY Knob 5
+extern const int CC1;
+extern const int CC2;
+extern const int CC3;
+extern const int CC4;
+extern const int CC5;		// change to 25 for EYESY Knob 5
 
-const int CC_AUX = 25; // Mother mode - AUX key
-const int CC_OM1 = 26; // Mother mode - enc switch 
-const int CC_OM2 = 28; // Mother mode - enc turn
+extern const int CC_AUX; // Mother mode - AUX key
+extern const int CC_OM1; // Mother mode - enc switch
+extern const int CC_OM2; // Mother mode - enc turn
 
-const int LED_BRIGHTNESS = 50;
+extern const int LED_BRIGHTNESS;
 
 // DONT CHANGE ANYTHING BELOW HERE
 
-const int LED_PIN  = 14;
-const int LED_COUNT = 27;
+extern const int LED_PIN;
+extern const int LED_COUNT;
 
 // POTS/ANALOG INPUTS
 // teensy pins for analog inputs 
-#if DEV			
-	const int analogPins[] = {23,22,21,20,16};	// DEV/beta boards
-#elif MIDIONLY
-	const int analogPins[] = {23,22,21,20,16};  // on MIDI only boards - {23,A10,21,20,16} on Bodged MIDI boards
-#else
-	const int analogPins[] = {A10,22,21,20,16}; // on 1.0
-#endif
+extern const int analogPins[];
 
 #define NUM_CC_POTS 5
-int pots[NUM_CC_POTS] = {CC1,CC2,CC3,CC4,CC5};			// the MIDI CC (continuous controller) for each analog input
+extern int pots[NUM_CC_POTS];			// the MIDI CC (continuous controller) for each analog input
 
-const int gridh = 32;
-const int gridw = 128;
-const int PPQ = 96;
+extern const int gridh;
+extern const int gridw;
+extern const int PPQ;
 
-const char* modes[] = {"MI","S1","S2","OM"};
-const char* infoDialogText[] = {"COPIED","PASTED","CLEARED","RESET","FWD >>","<< REV","SAVED","SAVE?"};
+extern const char* modes[];
+extern const char* infoDialogText[];
 
 enum multDiv
 {
@@ -74,8 +72,8 @@ enum multDiv
      NUM_MULTDIVS
 };
 
-float multValues[] = {.25, .5, 1, 2, 4, 8, 16};
-const char* mdivs[] = {"1/64", "1/32", "1/16", "1/8", "1/4", "1/2", "W"};
+extern float multValues[];
+extern const char* mdivs[];
 
 enum Dialogs{
      COPY = 0,
@@ -93,16 +91,8 @@ struct InfoDialogs {
   const char*  text;
   bool state;
 };
-InfoDialogs infoDialog[NUM_DIALOGS] = {
-  {"COPIED", false},
-  {"PASTED", false},
-  {"CLEARED", false},
-  {"RESET", false},
-  {"FWD >>", false},
-  {"<< REV", false},
-  {"SAVED", false},
-  {"SAVE?", false}
-};
+
+extern InfoDialogs infoDialog[NUM_DIALOGS];
 
 enum SubModes
 {
@@ -121,25 +111,14 @@ enum SubModes
 };
 
 // KEY SWITCH ROWS/COLS
-const byte ROWS = 5; //five rows
-const byte COLS = 6; //six columns
+#define ROWS 5 //five rows
+#define COLS 6 //six columns
 
 // Map the keys
-char keys[ROWS][COLS] = {
-  {0, 1, 2, 3, 4, 5},
-  {6, 7, 8, 9, 10,26},
-  {11,12,13,14,15,24},
-  {16,17,18,19,20,25},
-  {22,23,21}
-  };
-byte rowPins[ROWS] = {6, 4, 3, 5, 2}; // row pins for key switches
-byte colPins[COLS] = {7, 8, 10, 9, 15, 17}; // column pins for key switches
+extern char keys[ROWS][COLS];
+extern byte rowPins[ROWS]; // row pins for key switches
+extern byte colPins[COLS]; // column pins for key switches
 
 // KEYBOARD MIDI NOTE LAYOUT
-const int notes[] = {0,
-     61,63,   66,68,70,   73,75,   78,80,82,
-59,60,62,64,65,67,69,71,72,74,76,77,79,81,83,84};
-
-const int steps[] = {0,
-     1,2,   3,4,5,   6,7,   8,9,10,
-11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26};
+extern const int notes[];
+extern const int steps[];


### PR DESCRIPTION
The header needs to be limited to defining external variables and types, otherwise it cannot be included in multiple files. You can kind of think of it as forward declaring things. By putting the allocated objects in a .cpp file, you can "forward declare" the external variables in multiple files by including "config.h".