### PR TITLE
Scales

### DIFF
--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -1077,7 +1077,7 @@ void loop() {
 						}
 						strip.show();
 						// show the name of the scale for a moment
-						MESSAGE("%s %s", noteNames[scaleRoot], scaleNames[scalePattern]);
+						displayMessagef("%s %s", noteNames[scaleRoot], scaleNames[scalePattern]);
 						dirtyPixels = true;
 						break;
 					}
@@ -1520,9 +1520,9 @@ void loop() {
 							}
 							strip.show();
 							if(scaleDisplay) {
-								MESSAGE("SCALES ENABLED");
+								displayMessage("SCALES ENABLED");
 							} else {
-								MESSAGE("SCALES DISABLED");
+								displayMessage("SCALES DISABLED");
 							}
 							dirtyPixels = true;
 						} else if((thisKey >= 6 && thisKey <= 10) || thisKey >= 19) {
@@ -1543,7 +1543,7 @@ void loop() {
 							}
 							strip.show();
 							// show the name of the scale for a moment
-							MESSAGE("%s %s", noteNames[scaleRoot], scaleNames[scalePattern]);
+							displayMessagef("%s %s", noteNames[scaleRoot], scaleNames[scalePattern]);
 							dirtyPixels = true;
 						}
 					} else {
@@ -2025,10 +2025,6 @@ void loop() {
 
 //	if(dirtyDisplay && messageTextTimer > 0) {
 //	}
-
-	if(messageTextTimer > 0) {
-		displayMessage();
-	}
 
 	// DISPLAY at end of loop
 

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -452,13 +452,13 @@ const int scalePatterns[][7] = {
     // major / ionian
     {0, 2, 4, 5, 7, 9, 11},
     // dorian
-    {0, 2, 3, 5, 7, 9, 11},
+    {0, 2, 3, 5, 7, 9, 10},
     // phrygian
-    {0, 1, 3, 5, 7, 9, 11},
+    {0, 1, 3, 5, 7, 8, 10},
     // lydian
     {0, 2, 4, 6, 7, 9, 11},
     // mixolydian
-    {0, 2, 4, 6, 7, 9, 10},
+    {0, 2, 4, 5, 7, 9, 10},
     // minor / aeolian
     {0, 2, 3, 5, 7, 8, 10},
     // locrian
@@ -473,22 +473,22 @@ const int scalePatterns[][7] = {
     // lydian b7
     {0, 2, 4, 6, 7, 9, 10},
     // mixolydian b6
-    {0, 2, 4, 6, 7, 8, 10},
+    {0, 2, 4, 5, 7, 8, 10},
     // half-diminished (locrian natural 2)
     {0, 2, 3, 5, 6, 8, 10},
     // altered (super locrian)
-    {0, 1, 3, 4, 6, 10, 11},
+    {0, 1, 3, 4, 6, 8, 10},
 
     // harmonic minor
-    {0, 2, 4, 5, 7, 8, 11},
+    {0, 2, 3, 5, 7, 8, 11},
     // locrian 6
     {0, 1, 3, 5, 6, 9, 10},
     // ionian #5
     {0, 2, 4, 5, 8, 9, 11},
     // dorian #4
-    {0, 2, 3, 6, 7, 9, 11},
+    {0, 2, 3, 6, 7, 9, 10},
     // phrygian dominant
-    {0, 1, 4, 5, 7, 9, 10},
+    {0, 1, 4, 5, 7, 8, 10},
     // lydian #2
     {0, 3, 4, 6, 7, 9, 11},
     // super locrian bb7

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -418,6 +418,7 @@ void setup() {
 
 int scaleRoot = -1;
 int scalePattern = 0;
+bool scaleSelectHold;
 
 const char** messageText = NULL;
 int messageTextTimer = 0;
@@ -1068,6 +1069,18 @@ void loop() {
 					dirtyDisplay = true;
 //					break;
 				case MODE_MIDI: // MIDI
+					if (scaleSelectHold) {
+						scalePattern = WRAP(scalePattern + amt, getNumScales());
+						setScale(scaleRoot, scalePattern);
+						for(int n = 1; n < 27; n++) {
+							strip.setPixelColor(n, getDefaultColor(n));
+						}
+						strip.show();
+						// show the name of the scale for a moment
+						setMessage(scaleNames[scalePattern], 1000);
+						dirtyPixels = true;
+						break;
+					}
 					// CHANGE PAGE
 					if (miparam == 0 || miparam == 5 || miparam == 10) {
 						mmpage = constrain(mmpage + amt, 0, 2);
@@ -1511,6 +1524,7 @@ void loop() {
 						} else if((thisKey >= 6 && thisKey <= 10) || thisKey >= 19) {
 							int oldScaleRoot = scaleRoot;
 							scaleRoot = notes[thisKey] % 12;
+							scaleSelectHold = true;
 							if(scaleRoot == oldScaleRoot) {
 								// selecting same root again cycles through scales
 								scalePattern = (scalePattern + 1) % getNumScales();
@@ -1537,6 +1551,7 @@ void loop() {
 				} else if(e.bit.EVENT == KEY_JUST_RELEASED && thisKey != 0) {
 					//Serial.println(" released");
 					midiNoteOff(thisKey, midiChannel);
+					scaleSelectHold = false;
 				}
 
 				// AUX KEY

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -103,6 +103,10 @@ int selectedStep = 0;
 bool stepSelect = false;
 bool stepRecord = false;
 bool stepDirty = false;
+
+uint32_t stepColor = 0x000000;
+uint32_t muteColor = 0x000000;
+
 bool dialogFlags[] = {false, false, false, false, false, false};
 unsigned dialogDuration = 1000;
 
@@ -433,12 +437,7 @@ int getDefaultColor(int pixel) {
 			}
 		}
 		int noteInOct = notes[pixel] % 12;
-		int inScale = scaleOffsets[noteInOct];
-		if(inScale == -1) {
-			return LEDOFF;
-		} else {
-			return strip.gamma32(strip.ColorHSV((65535 / 12) * inScale, 127, 200));
-		}
+		return scaleColors[noteInOct];
 	}
 }
 

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -433,11 +433,11 @@ int getDefaultColor(int pixel) {
 			}
 		}
 		int noteInOct = notes[pixel] % 12;
-		int inScale = scaleDegrees[noteInOct];
+		int inScale = scaleOffsets[noteInOct];
 		if(inScale == -1) {
 			return LEDOFF;
 		} else {
-			return strip.gamma32(strip.ColorHSV((65535 / scaleLength) * inScale, 127, 200));
+			return strip.gamma32(strip.ColorHSV((65535 / 12) * inScale, 127, 200));
 		}
 	}
 }

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -426,6 +426,11 @@ int getDefaultColor(int pixel) {
 	if(scaleRoot == -1) {
 		return LEDOFF;
 	} else {
+		if(midiAUX) {
+			if(pixel == 1 || pixel == 2 || pixel == 11 || pixel == 12) {
+				return LEDOFF;
+			}
+		}
 		int noteInOct = notes[pixel] % 12;
 		int inScale = scaleDegrees[noteInOct];
 		if(inScale == -1) {

--- a/OMX-27-firmware/colors.h
+++ b/OMX-27-firmware/colors.h
@@ -90,3 +90,4 @@ const auto FUNKTWO = MINT;
 
 const auto SEQ1C = HALFWHITE;
 const auto SEQ2C = DKBLUE;
+

--- a/OMX-27-firmware/colors.h
+++ b/OMX-27-firmware/colors.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stdint.h>
-
 // COLOR PRESETS
 // https://www.rapidtables.com/web/color/color-wheel.html
 // hsl(xxx, 100%, 50%)
@@ -68,14 +66,10 @@ const auto HALFWHITE = 0x808080;
 const auto LOWWHITE = 0x202020;
 const auto LEDOFF = 0x000000;
 
-uint32_t stepColor = 0x000000;
-uint32_t muteColor = 0x000000;
-
 // sequencer pattern colors
 const uint32_t seqColors[] = {ORANGE,YELLOW,GREEN,MAGENTA,CYAN,BLUE,LIME,LTPURPLE};
 const uint32_t muteColors[] = {DKORANGE,DKYELLOW,DKGREEN,DKMAGENTA,DKCYAN,DKBLUE,DKLIME,DKPURPLE};
 const uint32_t sequencePageColors[] = {RED, ORANGE, YELLOW, LIME};
-
 
 const auto MIDINOTEON = HALFWHITE;
 const auto SEQCHASE = DKRED;

--- a/OMX-27-firmware/scales.cpp
+++ b/OMX-27-firmware/scales.cpp
@@ -6,104 +6,123 @@ int scaleDegrees[12];
 int scaleLength = 0;
 
 const int scalePatterns[][7] = {
-    // major / ionian
-    {0, 2, 4, 5, 7, 9, 11},
-    // dorian
-    {0, 2, 3, 5, 7, 9, 10},
-    // phrygian
-    {0, 1, 3, 5, 7, 8, 10},
-    // lydian
-    {0, 2, 4, 6, 7, 9, 11},
-    // mixolydian
-    {0, 2, 4, 5, 7, 9, 10},
-    // minor / aeolian
-    {0, 2, 3, 5, 7, 8, 10},
-    // locrian
-    {0, 1, 3, 5, 6, 8, 10},
+	// major / ionian
+	{0, 2, 4, 5, 7, 9, 11},
+	// dorian
+	{0, 2, 3, 5, 7, 9, 10},
+	// phrygian
+	{0, 1, 3, 5, 7, 8, 10},
+	// lydian
+	{0, 2, 4, 6, 7, 9, 11},
+	// mixolydian
+	{0, 2, 4, 5, 7, 9, 10},
+	// minor / aeolian
+	{0, 2, 3, 5, 7, 8, 10},
+	// locrian
+	{0, 1, 3, 5, 6, 8, 10},
 
-    // melodic minor
-    {0, 2, 3, 5, 7, 9, 11},
-    // dorian b2
-    {0, 1, 3, 5, 7, 9, 10},
-    // lydian #5
-    {0, 2, 4, 6, 8, 9, 11},
-    // lydian b7
-    {0, 2, 4, 6, 7, 9, 10},
-    // mixolydian b6
-    {0, 2, 4, 5, 7, 8, 10},
-    // half-diminished (locrian natural 2)
-    {0, 2, 3, 5, 6, 8, 10},
-    // altered (super locrian)
-    {0, 1, 3, 4, 6, 8, 10},
+	// melodic minor
+	{0, 2, 3, 5, 7, 9, 11},
+	// dorian b2
+	{0, 1, 3, 5, 7, 9, 10},
+	// lydian #5
+	{0, 2, 4, 6, 8, 9, 11},
+	// lydian b7
+	{0, 2, 4, 6, 7, 9, 10},
+	// mixolydian b6
+	{0, 2, 4, 5, 7, 8, 10},
+	// half-diminished (locrian natural 2)
+	{0, 2, 3, 5, 6, 8, 10},
+	// altered (super locrian)
+	{0, 1, 3, 4, 6, 8, 10},
 
-    // harmonic minor
-    {0, 2, 3, 5, 7, 8, 11},
-    // locrian 6
-    {0, 1, 3, 5, 6, 9, 10},
-    // ionian #5
-    {0, 2, 4, 5, 8, 9, 11},
-    // dorian #4
-    {0, 2, 3, 6, 7, 9, 10},
-    // phrygian dominant
-    {0, 1, 4, 5, 7, 8, 10},
-    // lydian #2
-    {0, 3, 4, 6, 7, 9, 11},
-    // super locrian bb7
-    {0, 1, 3, 4, 6, 8, 9},
+	// harmonic minor
+	{0, 2, 3, 5, 7, 8, 11},
+	// locrian 6
+	{0, 1, 3, 5, 6, 9, 10},
+	// ionian #5
+	{0, 2, 4, 5, 8, 9, 11},
+	// dorian #4
+	{0, 2, 3, 6, 7, 9, 10},
+	// phrygian dominant
+	{0, 1, 4, 5, 7, 8, 10},
+	// lydian #2
+	{0, 3, 4, 6, 7, 9, 11},
+	// super locrian bb7
+	{0, 1, 3, 4, 6, 8, 9},
 
-    // double harmonic
-    {0, 1, 4, 5, 7, 8, 11},
-    // lydian #2#6
-    {0, 3, 4, 6, 7, 10, 11},
-    // ultraphrygian
-    {0, 1, 3, 4, 7, 8, 9},
-    // hungarian
-    {0, 2, 3, 6, 7, 8, 11},
-    // oriental
-    {0, 1, 4, 5, 6, 9, 10},
-    // ionian #2#5
-    {0, 3, 4, 5, 8, 9, 11},
-    // locrian bb3bb7
-    {0, 2, 3, 5, 6, 8, 9},
+	// double harmonic
+	{0, 1, 4, 5, 7, 8, 11},
+	// lydian #2#6
+	{0, 3, 4, 6, 7, 10, 11},
+	// ultraphrygian
+	{0, 1, 3, 4, 7, 8, 9},
+	// hungarian
+	{0, 2, 3, 6, 7, 8, 11},
+	// oriental
+	{0, 1, 4, 5, 6, 9, 10},
+	// ionian #2#5
+	{0, 3, 4, 5, 8, 9, 11},
+	// locrian bb3bb7
+	{0, 2, 3, 5, 6, 8, 9},
 
-    // iwato
-    {0, 1, 5, 6, 10, -1, -1},
+	// pentatonic scales
+	// major pentatonic
+	{0, 2, 4, 7, 9, -1, -1},
+	// minor pentatonic
+	{0, 3, 5, 7, 9, -1, -1},
+	// in sen (japanese)
+	{0, 1, 5, 7, 10, -1, -1},
+	// iwato
+	{0, 1, 5, 6, 10, -1, -1},
+	// yo
+	{0, 2, 5, 7, 9, -1, -1},
+	// hirajoshi
+	{0, 2, 3, 7, 8, -1, -1},
+	// egyptian
+	{0, 2, 5, 7, 10, -1 , -1},
 };
 
 const char* scaleNames[] = {
-    "major",
-    "dorian",
-    "phrygian",
-    "lydian",
-    "mixolydian",
-    "minor",
-    "locrian",
+	"major",
+	"dorian",
+	"phrygian",
+	"lydian",
+	"mixolydian",
+	"minor",
+	"locrian",
 
-    "mel. minor",
-    "dorian b2",
-    "lydian #5",
-    "lydian b7",
-    "mixo b6",
-    "half-dim",
-    "altered",
+	"mel. minor",
+	"dorian b2",
+	"lydian #5",
+	"lydian b7",
+	"mixo b6",
+	"half-dim",
+	"altered",
 
-    "harm. minor",
-    "locrian 6",
-    "ionian #5",
-    "dorian #4",
-    "phrygian dom.",
-    "lydian #2",
-    "sup loc bb7",
+	"harm. minor",
+	"locrian 6",
+	"ionian #5",
+	"dorian #4",
+	"phrygian dom.",
+	"lydian #2",
+	"sup loc bb7",
 
-    "dbl harm.maj",
-    "lydian #2#6",
-    "ultraphrygian",
-    "hungarian",
-    "oriental",
-    "ionian #2#5",
-    "loc. bb3bb7",
+	"dbl harm.maj",
+	"lydian #2#6",
+	"ultraphrygian",
+	"hungarian",
+	"oriental",
+	"ionian #2#5",
+	"loc. bb3bb7",
 
-    "iwato",
+	"penta maj",
+	"penta min",
+	"in sen",
+	"iwato",
+	"yo",
+	"hirajoshi",
+	"egyptian",
 };
 
 const char* noteNames[] = {

--- a/OMX-27-firmware/scales.cpp
+++ b/OMX-27-firmware/scales.cpp
@@ -1,9 +1,15 @@
+#include <cstdint>
 #include "scales.h"
+#include "colors.h"
 #include "util.h"
 
 int scaleOffsets[12];
 int scaleDegrees[12];
+int scaleColors[12];
 int scaleLength = 0;
+
+#include <Adafruit_NeoPixel.h>
+extern Adafruit_NeoPixel strip;
 
 const int scalePatterns[][7] = {
 	// major / ionian
@@ -148,6 +154,7 @@ void setScale(int scaleRoot, int scalePattern) {
 		for(int n = 0; n < 12; n++) {
 			scaleOffsets[n] = -1;
 			scaleDegrees[n] = -1;
+			scaleColors[n] = LEDOFF;
 		}
 	} else {
 		for(int n = 0; n < 12; n++) {
@@ -166,6 +173,11 @@ void setScale(int scaleRoot, int scalePattern) {
 			}
 			scaleOffsets[n] = offset;
 			scaleDegrees[n] = degree;
+			if(degree == -1) {
+				scaleColors[n] = LEDOFF;
+			} else {
+				scaleColors[n] = strip.gamma32(strip.ColorHSV((65535 / 12) * offset, 127, 200));
+			}
 		}
 	}
 	scaleLength = 0;

--- a/OMX-27-firmware/scales.cpp
+++ b/OMX-27-firmware/scales.cpp
@@ -1,0 +1,163 @@
+#include "scales.h"
+#include "util.h"
+
+int scaleOffsets[12];
+int scaleDegrees[12];
+int scaleLength = 0;
+
+const int scalePatterns[][7] = {
+    // major / ionian
+    {0, 2, 4, 5, 7, 9, 11},
+    // dorian
+    {0, 2, 3, 5, 7, 9, 10},
+    // phrygian
+    {0, 1, 3, 5, 7, 8, 10},
+    // lydian
+    {0, 2, 4, 6, 7, 9, 11},
+    // mixolydian
+    {0, 2, 4, 5, 7, 9, 10},
+    // minor / aeolian
+    {0, 2, 3, 5, 7, 8, 10},
+    // locrian
+    {0, 1, 3, 5, 6, 8, 10},
+
+    // melodic minor
+    {0, 2, 3, 5, 7, 9, 11},
+    // dorian b2
+    {0, 1, 3, 5, 7, 9, 10},
+    // lydian #5
+    {0, 2, 4, 6, 8, 9, 11},
+    // lydian b7
+    {0, 2, 4, 6, 7, 9, 10},
+    // mixolydian b6
+    {0, 2, 4, 5, 7, 8, 10},
+    // half-diminished (locrian natural 2)
+    {0, 2, 3, 5, 6, 8, 10},
+    // altered (super locrian)
+    {0, 1, 3, 4, 6, 8, 10},
+
+    // harmonic minor
+    {0, 2, 3, 5, 7, 8, 11},
+    // locrian 6
+    {0, 1, 3, 5, 6, 9, 10},
+    // ionian #5
+    {0, 2, 4, 5, 8, 9, 11},
+    // dorian #4
+    {0, 2, 3, 6, 7, 9, 10},
+    // phrygian dominant
+    {0, 1, 4, 5, 7, 8, 10},
+    // lydian #2
+    {0, 3, 4, 6, 7, 9, 11},
+    // super locrian bb7
+    {0, 1, 3, 4, 6, 8, 9},
+
+    // double harmonic
+    {0, 1, 4, 5, 7, 8, 11},
+    // lydian #2#6
+    {0, 3, 4, 6, 7, 10, 11},
+    // ultraphrygian
+    {0, 1, 3, 4, 7, 8, 9},
+    // hungarian
+    {0, 2, 3, 6, 7, 8, 11},
+    // oriental
+    {0, 1, 4, 5, 6, 9, 10},
+    // ionian #2#5
+    {0, 3, 4, 5, 8, 9, 11},
+    // locrian bb3bb7
+    {0, 2, 3, 5, 6, 8, 9},
+
+    // iwato
+    {0, 1, 5, 6, 10, -1, -1},
+};
+
+const char* scaleNames[] = {
+    "major",
+    "dorian",
+    "phrygian",
+    "lydian",
+    "mixolydian",
+    "minor",
+    "locrian",
+
+    "mel. minor",
+    "dorian b2",
+    "lydian #5",
+    "lydian b7",
+    "mixo b6",
+    "half-dim",
+    "altered",
+
+    "harm. minor",
+    "locrian 6",
+    "ionian #5",
+    "dorian #4",
+    "phrygian dom.",
+    "lydian #2",
+    "sup loc bb7",
+
+    "dbl harm.maj",
+    "lydian #2#6",
+    "ultraphrygian",
+    "hungarian",
+    "oriental",
+    "ionian #2#5",
+    "loc. bb3bb7",
+
+    "iwato",
+};
+
+const char* noteNames[] = {
+	"C",
+	"C#",
+	"D",
+	"D#",
+	"E",
+	"F",
+	"F#",
+	"G",
+	"G#",
+	"A",
+	"A#",
+	"B",
+};
+
+
+
+void setScale(int scaleRoot, int scalePattern) {
+	if(scaleRoot == -1) {
+		// disabled
+		for(int n = 0; n < 12; n++) {
+			scaleOffsets[n] = -1;
+			scaleDegrees[n] = -1;
+		}
+	} else {
+		for(int n = 0; n < 12; n++) {
+			int offset = -1;
+			int degree = -1;
+			for(int j = 0; j < 7; j++) {
+				int v = scalePatterns[scalePattern][j];
+				if(v == -1) {
+					continue;
+				}
+				if((scaleRoot + v) % 12 == n) {
+					offset = v;
+					degree = j;
+					break;
+				}
+			}
+			scaleOffsets[n] = offset;
+			scaleDegrees[n] = degree;
+		}
+	}
+	scaleLength = 0;
+	for(int j = 0; j < 7; j++) {
+		int v = scalePatterns[scalePattern][j];
+		if(v != -1) {
+			scaleLength++;
+		}
+	}
+}
+
+int getNumScales() {
+	return ARRAYLEN(scalePatterns);
+}

--- a/OMX-27-firmware/scales.h
+++ b/OMX-27-firmware/scales.h
@@ -2,6 +2,7 @@
 
 extern int scaleDegrees[12];
 extern int scaleOffsets[12];
+extern int scaleColors[12];
 extern const char* scaleNames[];
 extern const char* noteNames[];
 extern const int scalePatterns[][7];

--- a/OMX-27-firmware/scales.h
+++ b/OMX-27-firmware/scales.h
@@ -1,0 +1,10 @@
+#pragma once
+
+extern int scaleDegrees[12];
+extern const char* scaleNames[];
+extern const char* noteNames[];
+extern const int scalePatterns[][7];
+
+void setScale(int scaleRoot, int scalePattern);
+int getNumScales();
+extern int scaleLength;

--- a/OMX-27-firmware/scales.h
+++ b/OMX-27-firmware/scales.h
@@ -1,6 +1,7 @@
 #pragma once
 
 extern int scaleDegrees[12];
+extern int scaleOffsets[12];
 extern const char* scaleNames[];
 extern const char* noteNames[];
 extern const int scalePatterns[][7];

--- a/OMX-27-firmware/util.h
+++ b/OMX-27-firmware/util.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#define WRAP(a, b) ((b) + ((a)%(b))) % (b)
+#define ARRAYLEN(x) (sizeof(x) / sizeof(x[0]))


### PR DESCRIPTION
Adds support for a variety of scales based on the modes of major, melodic minor and harmonic minor scales and some pentatonic scales, it should be trivial to add more scales in the future.

To use, hold AUX and press the root note for the scale (upper octave only), hold AUX and press root note again to cycle between scales, or while still holding the root note, turn the encoder to select a scale.
Hold AUX and press the top C to disable scale display.

Root note shows as Rose and other notes follow to form a pastel rainbow based on their interval allowing quick jumping to any interval by color, eg perfect fifth will always be blue, leading tone will always be pink, tritone will always be cyan.