### PR TITLE
WIP: Introduce Note GATE Length Sequence Pattern Param

### DIFF
--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -800,7 +800,7 @@ void dispGenericMode(int submode, int selected){
 		case SUBMODE_PATTPARAMS3:
 			legends[0] = "RATE";
 			legends[1] = "SOLO";
-			legends[2] = "---";
+			legends[2] = "GATE";
 			legends[3] = "---";
 
 			// RATE FOR CURR PATTERN
@@ -808,7 +808,10 @@ void dispGenericMode(int submode, int selected){
 			legendText[0] = mdivs[patternSettings[playingPattern].clockDivMultP];
 
 			legendVals[1] = patternSettings[playingPattern].solo;
-			legendVals[2] = 0; 			// TBD
+
+			legendVals[2] = -127;
+			legendText[2] = gpers[patternSettings[playingPattern].gateLenDivP];  // Note Length as Percent of "Step Slot"
+
 			legendVals[3] = 0;			// TBD
 			dispPage = 3;
 			break;
@@ -1210,6 +1213,9 @@ void loop() {
 						if (ppparam == 12) { 					// SET MIDI SOLO
 							patternSettings[playingPattern].solo = constrain(patternSettings[playingPattern].solo + amt, 0, 1);
 						}
+						if (ppparam == 13){ 					// SET gateLenDivP: Gate length as percentage of "sequencer note slot length"
+						    patternSettings[playingPattern].gateLenDivP = constrain(patternSettings[playingPattern].gateLenDivP + amt, 0, NUM_GATEPERCENTAGES-1);
+					    }
 
 					// STEP RECORD MODE
 					} else if (stepRecord && !enc_edit){
@@ -2414,9 +2420,10 @@ void playNote(int patternNum) {
 	if (stepNoteP[patternNum][seqPos[patternNum]].trig == TRIGTYPE_PLAY){
 
 		seq_velocity = stepNoteP[patternNum][seqPos[patternNum]].vel;
-
-		noteoff_micros = micros() + ( stepNoteP[patternNum][seqPos[patternNum]].len + 1 )* step_micros ;
-		pendingNoteOffs.insert(stepNoteP[patternNum][seqPos[patternNum]].note, PatternChannel(patternNum), noteoff_micros, sendnoteCV );
+		// gateLenDivP allows us to adjust the gate length for a note by percentage of "sequencer slot length".
+		// The default value (0) equates to 100% of step slot being consumed by the note on/off
+		noteoff_micros = micros() + ( (stepNoteP[patternNum][seqPos[patternNum]].len + 1) * gateValues[patternSettings[playingPattern].gateLenDivP] )* step_micros ;
+		pendingNoteOffs.insert(stepNoteP[patternNum][seqPos[patternNum]].note, PatternChannel(patternNum), noteoff_micros, sendnoteCV );	
 
 		if (seqPos[patternNum] % 2 == 0){
 
@@ -2695,6 +2702,7 @@ void initPatterns( void ) {
 		patternSettings[i].rndstep = 3;
 		patternSettings[i].autoreset = false;
 		patternSettings[i].solo = false;
+		patternSettings[i].gateLenDivP = 0;
 	}
 }
 

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -301,6 +301,7 @@ void setup() {
 		timePerPattern[x].nextStepTimeP = nextStepTime; // initialize all patterns
 		timePerPattern[x].lastStepTimeP = lastStepTime; // initialize all patterns
 		patternSettings[x].clockDivMultP = 2; // set all DivMult to 2 for now
+		patternSettings[x].gateLenDivP = GATE_HALF; // forcing default of GATE length 50% for now
 	}
 	randomSeed(analogRead(13));
 

--- a/OMX-27-firmware/config.cpp
+++ b/OMX-27-firmware/config.cpp
@@ -48,6 +48,9 @@ const char* infoDialogText[] = {"COPIED","PASTED","CLEARED","RESET","FWD >>","<<
 float multValues[] = {.25, .5, 1, 2, 4, 8, 16};
 const char* mdivs[] = {"1/64", "1/32", "1/16", "1/8", "1/4", "1/2", "W"};
 
+float gateValues[] = {.1, .25, .33, .50, .66, .75, .90, 1};
+const char* gpers[] = {"10%", "25%", "33%", "50%", "66%", "75%", "90%", "100%"};
+
 InfoDialogs infoDialog[NUM_DIALOGS] = {
   {"COPIED", false},
   {"PASTED", false},

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -79,6 +79,22 @@ enum multDiv
 extern float multValues[];
 extern const char* mdivs[];
 
+enum gateLengthPercentages{
+     GATE_FULL = 0,
+     GATE_NINETENTH,
+     GATE_THREEFOURTH,
+     GATE_TWOTHIRD,
+     GATE_HALF,
+     GATE_THIRD,
+     GATE_QUARTER,
+     GATE_TENTH,
+
+     NUM_GATEPERCENTAGES
+};
+
+extern float gateValues[];
+extern const char* gpers[];
+
 enum Dialogs{
      COPY = 0,
      PASTE,

--- a/OMX-27-firmware/sequencer.h
+++ b/OMX-27-firmware/sequencer.h
@@ -62,17 +62,18 @@ struct PatternSettings {  // ?? bytes
   bool mute : 1;
   bool autoreset : 1; // whether autoreset is enabled
   bool solo : 1;
+  uint8_t gateLenDivP : 3; // Dictates what percentage of a step a note consumes: Default 0 consumes whole step, 1 = 1/2, 2 = 1/3, 3 = 1/4 
 }; // ? bytes
 
 PatternSettings patternSettings[NUM_PATTERNS] = {
-  { 15, 0, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 1, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 2, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 3, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 4, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 5, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 6, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false },
-  { 15, 7, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false }
+  { 15, 0, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 1, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 2, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 3, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 4, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 5, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 6, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF },
+  { 15, 7, 0, 0, 0, 0, 1, 3, 1, 0, false, false, false, false, GATE_HALF }
 };
 
 struct TimePerPattern {


### PR DESCRIPTION
Up until this PR, all sequenced notes played  in legato -- i.e., a note length of one (1) consumes one (1) "sequence step slot" and thus the percentage of a "step slot length" consumed by a single "note on gate" (note length=1) consumes 100% of the corresponding "step slot." 

The feature being proposed with this PR  introduces the GATE sequence parameter which allows the ability to adjust what percentage of a "step slot" is consumed by the gate of a "note on" event. In more musical terms, this allows notes to be played with various degrees of "staccato" for the given sequence being adjusted.

At the moment, using a very simple algorithm for optional values, the following note length percentages are available to set per pattern:

* 10% - 1/10th of "note step slot"
* 25% - 1/4
* 33% - 1/3
* 50% - 1/2 - current default
* 66% - 2/3
* 75% - 3/4
* 90% - 9/10
* 100% - 1/1 - Legacy "legato"

NOTE: Currently set to use 50% as default value.

