### PR TITLE
Small refactor of SysSettings plumbing

### DIFF
--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -29,6 +29,8 @@
 
 U8G2_FOR_ADAFRUIT_GFX u8g2_display;
 
+SysSettings sysSettings;
+
 const int potCount = 5;
 ResponsiveAnalogRead *analog[potCount];
 
@@ -314,7 +316,7 @@ void setup() {
 	Serial.begin(115200);
 
 	storage = Storage::initStorage();
-	sysEx = new SysEx(storage);
+	sysEx = new SysEx(storage, &sysSettings);
 
 	// incoming usbMIDI callbacks
 	usbMIDI.setHandleNoteOff(OnNoteOff);
@@ -1888,7 +1890,7 @@ void loop() {
 			messageTextTimer = 0;
 		}
 	}
-	
+
 	switch(sysSettings.omxMode){
 		case MODE_OM: 						// ############## ORGANELLE MODE
 			// FALL THROUGH
@@ -2297,7 +2299,7 @@ bool loadHeader( void ) {
 
 	uint8_t unMidiChannel = storage->read( EEPROM_HEADER_ADDRESS + 3 );
 	sysSettings.midiChannel = unMidiChannel + 1;
-	
+
 	for (int b=0; b < NUM_CC_BANKS; b++){
 		for ( int i=0; i<NUM_CC_POTS; i++ ) {
 			pots[b][i] = storage->read( EEPROM_HEADER_ADDRESS + 4 + i + (5*b));

--- a/OMX-27-firmware/config.cpp
+++ b/OMX-27-firmware/config.cpp
@@ -38,8 +38,6 @@ int pots[NUM_CC_BANKS][NUM_CC_POTS] = {
 	{91,93,103,104,7}
 };          // the MIDI CC (continuous controller) for each analog input
 
-SysSettings sysSettings;
-
 const int gridh = 32;
 const int gridw = 128;
 const int PPQ = 96;

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -69,7 +69,6 @@ struct SysSettings {
 	int playingPattern;
 	bool refresh = false;
 };
-extern SysSettings sysSettings;
 
 #define NUM_DISP_PARAMS 5
 

--- a/OMX-27-firmware/sequencer.cpp
+++ b/OMX-27-firmware/sequencer.cpp
@@ -9,7 +9,7 @@
 
 // globals in main ino
 extern SequencerState sequencer;
-// extern OMXMode omxMode;
+extern SysSettings sysSettings;
 
 // extern int midiChannel;
 extern int selectedStep;

--- a/OMX-27-firmware/sysex.cpp
+++ b/OMX-27-firmware/sysex.cpp
@@ -78,16 +78,16 @@ void SysEx::updateSettingsBlockAndStore(const uint8_t* configFromSysex, unsigned
 
 void SysEx::loadGlobals( void ) {
 // 	uint8_t version = this->storage->read(EEPROM_HEADER_ADDRESS + 0);
-	sysSettings.omxMode = (OMXMode)this->storage->read( EEPROM_HEADER_ADDRESS + 1 );
-	sysSettings.playingPattern = this->storage->read(EEPROM_HEADER_ADDRESS + 2);
+	this->settings->omxMode = (OMXMode)this->storage->read( EEPROM_HEADER_ADDRESS + 1 );
+	this->settings->playingPattern = this->storage->read(EEPROM_HEADER_ADDRESS + 2);
 	uint8_t unMidiChannel = this->storage->read( EEPROM_HEADER_ADDRESS + 3 );
-	sysSettings.midiChannel = unMidiChannel + 1;
+	this->settings->midiChannel = unMidiChannel + 1;
 	for (int b=0; b < NUM_CC_BANKS; b++){
 		for ( int i=0; i<NUM_CC_POTS; i++ ) {
 			pots[b][i] = this->storage->read( EEPROM_HEADER_ADDRESS + 4 + i + (5*b));
 		}
 	}
-	sysSettings.refresh = true;
+	this->settings->refresh = true;
 }
 
 void SysEx::sendCurrentState() {

--- a/OMX-27-firmware/sysex.h
+++ b/OMX-27-firmware/sysex.h
@@ -1,15 +1,17 @@
 #pragma once
 
 #include "storage.h"
+#include "config.h"
 
 class SysEx {
 	Storage *storage;
+	SysSettings *settings;
 
 public:
 
-	SysEx(Storage* storage) {
-		this->storage = storage;
-	}
+	SysEx(Storage* storage, SysSettings* settings) :
+		storage(storage),
+		settings(settings) {}
 
 	void processIncomingSysex(const uint8_t* sysexData, unsigned size);
 	void updateAllSettingsAndStore(const uint8_t* newConfig, unsigned size);


### PR DESCRIPTION
As per out DM's, small tweak to how SysSettings are passed around so's to use [Dependency Injection](https://en.wikipedia.org/wiki/Dependency_injection) to provide a reference to the settings to the `SysEx` class.