### PR TITLE
Code cleanup and refactor

### DIFF
--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -11,7 +11,6 @@
 //  Additional code contributions: Matt Boone, Steven Zydek, Chris Atkins, Will Winder
 
 #include <functional>
-// #include <Adafruit_NeoPixel.h>
 #include <ResponsiveAnalogRead.h>
 
 #include "consts.h"
@@ -26,16 +25,13 @@
 #include "omx_keypad.h"
 #include "omx_util.h"
 #include "omx_disp.h"
-
 #include "omx_mode_midi_keyboard.h"
 #include "omx_mode_sequencer.h"
 #include "omx_screensaver.h"
 #include "omx_leds.h"
 
 OmxModeMidiKeyboard omxModeMidi;
-// OmxModeMidiKeyboard omxModeOM;
 OmxModeSequencer omxModeSeq;
-// OmxModeSequencer omxModeS2;
 
 OmxModeInterface *activeOmxMode;
 
@@ -48,69 +44,11 @@ int potMin = 0;
 int potMax = 8190;
 int temp;
 
-// TODO make sequencer.cpp not extern these
-// int selectedStep = 0;
-// int potbank = 0;
-// int prevPlock[NUM_CC_POTS] = {0, 0, 0, 0, 0};
-// int potValues[NUM_CC_POTS] = {0, 0, 0, 0, 0};
-
-// Timers and such
-// elapsedMillis blink_msec = 0;
-// elapsedMillis slow_blink_msec = 0;
-// elapsedMillis pots_msec = 0; // TODO - didn't see this used anywhere
-
-// elapsedMicros clksTimer = 0; // TODO - didn't see this used anywhere
-
-// unsigned long clksDelay;
-// elapsedMillis keyPressTime[27] = {0};
-
-// using Micros = unsigned long;
 Micros lastProcessTime;
-// volatile unsigned long step_micros;
-// volatile unsigned long noteon_micros;
-// volatile unsigned long noteoff_micros;
-// volatile unsigned long ppqInterval;
-
-// bool screenSaverMode = false;
-
-// int sleepTick = 80;
-
-// DEFAULT COLOR VARIABLES
-
-// int nspage = 0;
-// int pppage = 0;
-// int sqpage = 0;
-// int srpage = 0;
-// int mmpage = 0;
-
-// int miparam = 0;	// midi params item counter
-// int nsparam = 0;	// note select params
-// int ppparam = 0;	// pattern params
-// int sqparam = 0;	// seq params
-// int srparam = 0;	// step record params
-// int tmpmmode = 9; TODO - didn't see this used anywhere
-
-// VARIABLES / FLAGS
-// float step_delay;
-// bool dirtyPixels = false;
-
-// bool blinkState = false;
-// bool slowBlinkState = false;
-
-// bool patternParams = false;
-// bool seqPages = false;
-// int noteSelectPage = 0; TODO - didn't see this used anywhere
-
-// bool dialogFlags[] = {false, false, false, false, false, false}; // TODO - didn't see this used anywhere
-// unsigned dialogDuration = 1000; // TODO - didn't see this used anywhere
 
 uint8_t RES;
 uint16_t AMAX;
 int V_scale;
-
-// unsigned long blinkInterval = clockConfig.clockbpm * 2;
-
-// int midiChannel; // the MIDI channel number to send messages (MIDI/OM mode)
 
 // ENCODER
 Encoder myEncoder(12, 11); // encoder pins on hardware
@@ -123,9 +61,6 @@ Button encButton(0);	   // encoder button pin on hardware
 unsigned long longPressInterval = 800;
 unsigned long clickWindow = 200;
 OMXKeypad keypad(longPressInterval, clickWindow, makeKeymap(keys), rowPins, colPins, ROWS, COLS);
-
-// // Declare NeoPixel strip object
-// Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 
 // setup EEPROM/FRAM storage
 Storage *storage;
@@ -237,20 +172,6 @@ void show_current_step(int patternNum)
 	omxLeds.updateLeds();
 
 	omxModeSeq.showCurrentStep(patternNum);
-
-	/*
-	blinkInterval = step_delay*2;
-	unsigned long slowBlinkInterval = blinkInterval * 2;
-
-	if (blink_msec >= blinkInterval){
-		blinkState = !blinkState;
-		blink_msec = 0;
-	}
-	if (slow_blink_msec >= slowBlinkInterval){
-		slowBlinkState = !slowBlinkState;
-		slow_blink_msec = 0;
-	}
-	*/
 }
 
 void changeOmxMode(OMXMode newOmxmode)
@@ -491,14 +412,6 @@ void loop()
 } // ######## END MAIN LOOP ########
 
 // ####### POTENTIOMETERS #######
-
-// void sendPots(int val, int channel){
-// 	MM::sendControlChange(pots[potbank][val], analogValues[val], channel);
-// 	potCC = pots[potbank][val];
-// 	potVal = analogValues[val];
-// 	potValues[val] = potVal;
-// }
-
 void readPotentimeters()
 {
 	for (int k = 0; k < potCount; k++)
@@ -519,12 +432,12 @@ void readPotentimeters()
 			// do stuff
 			if (sysSettings.screenSaverMode)
 			{
-				omxScreensaver.OnPotChanged(k, potSettings.analogValues[k]);
+				omxScreensaver.onPotChanged(k, potSettings.analogValues[k]);
 			}
 			else
 			{ // don't send pots in screensaver
 				{
-					activeOmxMode->OnPotChanged(k, potSettings.analogValues[k]);
+					activeOmxMode->onPotChanged(k, potSettings.analogValues[k]);
 				}
 			}
 		}

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -14,7 +14,6 @@
 #include <functional>
 #include <Adafruit_NeoPixel.h>
 #include <ResponsiveAnalogRead.h>
-#include <U8g2_for_Adafruit_GFX.h>
 
 #include "consts.h"
 #include "config.h"
@@ -26,10 +25,8 @@
 #include "storage.h"
 #include "sysex.h"
 #include "omx_keypad.h"
-
-U8G2_FOR_ADAFRUIT_GFX u8g2_display;
-
-SysSettings sysSettings;
+#include "omx_util.h"
+#include "omx_disp.h"
 
 const int potCount = 5;
 ResponsiveAnalogRead *analog[potCount];
@@ -76,16 +73,6 @@ uint16_t midiBg_Hue = 0;
 uint8_t midiBg_Sat = 255;
 uint8_t midiBg_Brightness = 255;
 
-// ANALOGS
-int potbank = 0;
-int analogValues[] = {0,0,0,0,0};		// default values
-int potValues[] = {0,0,0,0,0};
-int potCC = pots[potbank][0];
-int potVal = analogValues[0];
-int potNum = 0;
-bool plockDirty[] = {false,false,false,false,false};
-int prevPlock[] = {0,0,0,0,0};
-
 int nspage = 0;
 int pppage = 0;
 int sqpage = 0;
@@ -105,7 +92,7 @@ SequencerState sequencer = defaultSequencer();
 // VARIABLES / FLAGS
 float step_delay;
 bool dirtyPixels = false;
-bool dirtyDisplay = false;
+
 bool blinkState = false;
 bool slowBlinkState = false;
 bool noteSelect = false;
@@ -127,17 +114,9 @@ bool clearedFlag = false;
 
 bool enc_edit = false;
 bool midiAUX = false;
-int midiMacro = 0;
-bool m8AUX = false;
-int midiMacroChan = 10;
+
 bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
 
-int defaultVelocity = 100;
-int octave = 0;			// default C4 is 0 - range is -4 to +5
-int newoctave = octave;
-int transpose = 0;
-int rotationAmt = 0;
-int hline = 8;
 int pitchCV;
 uint8_t RES;
 uint16_t AMAX;
@@ -150,50 +129,9 @@ unsigned long tempoStartTime, tempoEndTime;
 
 unsigned long blinkInterval = clockbpm * 2;
 
-uint8_t swing = 0;
-const int maxswing = 100;
-// int swing_values[maxswing] = {0, 1, 3, 5, 52, 66, 70, 72, 80, 99 }; // 0 = off, <50 early swing , >50 late swing, 99=drunken swing
 
-bool keyState[27] = {false};
-int midiKeyState[27] =     {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
-int midiChannelState[27] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
-int rrChannel = 0;
-bool midiRoundRobin = false;
-int midiRRChannelCount = 1;
-int midiRRChannelOffset = 0;
-int currpgm = 0;
-int currbank = 0;
-bool midiInToCV = true;
-uint8_t midiLastNote = 0;
-bool midiSoftThru = false;
 
 //int midiChannel; // the MIDI channel number to send messages (MIDI/OM mode)
-
-// MESSAGE DISPLAY
-const int MESSAGE_TIMEOUT_US = 500000;
-int messageTextTimer = 0;
-
-void displayMessage(const char* msg) {
-    display.fillRect(0, 0, 128, 32, BLACK);
-    u8g2_display.setFontMode(1);
-    u8g2_display.setFont(FONT_TENFAT);
-    u8g2_display.setForegroundColor(WHITE);
-    u8g2_display.setBackgroundColor(BLACK);
-    u8g2centerText(msg, 0, 10, 128, 32);
-
-    messageTextTimer = MESSAGE_TIMEOUT_US;
-    dirtyDisplay = true;
-}
-
-void displayMessagef(const char* fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    char buf[24];
-    vsnprintf(buf, sizeof(buf), fmt, args);
-    va_end(args);
-    displayMessage(buf);
-}
-
 
 // ENCODER
 Encoder myEncoder(12, 11); 	// encoder pins on hardware
@@ -260,12 +198,12 @@ void setGlobalSwing(int swng_amt){
 
 // ####### POTENTIOMETERS #######
 
-void sendPots(int val, int channel){
-	MM::sendControlChange(pots[potbank][val], analogValues[val], channel);
-	potCC = pots[potbank][val];
-	potVal = analogValues[val];
-	potValues[val] = potVal;
-}
+// void sendPots(int val, int channel){
+// 	MM::sendControlChange(pots[potbank][val], analogValues[val], channel);
+// 	potCC = pots[potbank][val];
+// 	potVal = analogValues[val];
+// 	potValues[val] = potVal;
+// }
 
 void readPotentimeters(){
 	for(int k=0; k<potCount; k++) {
@@ -296,13 +234,13 @@ void readPotentimeters(){
 						// fall through - same as MIDI
 				case MODE_MIDI: // MIDI
 					if (midiMacro && !screenSaverMode){
-						sendPots(k, midiMacroChan);
+						omxutil.sendPots(k, midiMacroChan);
 					} else if (screenSaverMode) {
 						// don't send pots in screensaver
 					} else {
-						sendPots(k, sysSettings.midiChannel);
+						omxutil.sendPots(k, sysSettings.midiChannel);
 					}
-					dirtyDisplay = true;
+					omxidsp.setDispDirty();
 					break;
 
 				case MODE_S2: // SEQ2
@@ -315,11 +253,10 @@ void readPotentimeters(){
 
 						if (k < 4){ // only store p-lock value for first 4 knobs
 							getSelectedStep()->params[k] = analogValues[k];
-							sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
+							omxutil.sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
 						}
-						sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
-						dirtyDisplay = true;
-
+						omxutil.sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
+						omxidsp.setDispDirty();
 					} else if (stepRecord){
 						potNum = k;
 						potCC = pots[potbank][k];
@@ -327,13 +264,13 @@ void readPotentimeters(){
 
 						if (k < 4){ // only store p-lock value for first 4 knobs
 							sequencer.getCurrentPattern()->steps[sequencer.seqPos[sequencer.playingPattern]].params[k] = analogValues[k];
-							sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
+							omxutil.sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
 						} else if (k == 4){
 							sequencer.getCurrentPattern()->steps[sequencer.seqPos[sequencer.playingPattern]].vel = analogValues[k]; // SET POT 5 to NOTE VELOCITY HERE
 						}
-						dirtyDisplay = true;
+						omxidsp.setDispDirty();
 					} else if (!noteSelect || !stepRecord){
-						sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
+						omxutil.sendPots(k, sequencer.getPatternChannel(sequencer.playingPattern));
 					}
 					break;
 
@@ -420,17 +357,10 @@ void setup() {
 	}
 
 	// Init Display
-	initializeDisplay();
-	u8g2_display.begin(display);
+	omxidsp.setup();
 
 	// Startup screen
-	display.clearDisplay();
-	testdrawrect();
-	delay(200);
-	display.clearDisplay();
-	u8g2_display.setForegroundColor(WHITE);
-	u8g2_display.setBackgroundColor(BLACK);
-	drawLoading();
+	omxidsp.drawStartupScreen();
 
 	// Keypad
 //	customKeypad.begin();
@@ -454,10 +384,7 @@ void setup() {
 
 	delay(100);
 
-	// Clear display
-	display.display();
-
-	dirtyDisplay = true;
+	
 }
 
 // ####### END SETUP #######
@@ -857,309 +784,6 @@ void sleepModeOne(){
 
 
 // ####### DISPLAY FUNCTIONS #######
-
-void dispGridBoxes(){
-	display.fillRect(0, 0, gridw, 10, WHITE);
-	display.drawFastVLine(gridw/4, 0, gridh, INVERSE);
-	display.drawFastVLine(gridw/2, 0, gridh, INVERSE);
-	display.drawFastVLine(gridw*0.75, 0, gridh, INVERSE);
-}
-void invertColor(bool flip){
-	if (flip) {
-		u8g2_display.setForegroundColor(BLACK);
-		u8g2_display.setBackgroundColor(WHITE);
-	} else {
-		u8g2_display.setForegroundColor(WHITE);
-		u8g2_display.setBackgroundColor(BLACK);
-	}
-}
-void dispValBox(int v, int16_t n, bool inv){			// n is box 0-3
-	invertColor(inv);
-	u8g2centerNumber(v, n*32, hline*2+3, 32, 22);
-}
-
-void dispSymbBox(const char* v, int16_t n, bool inv){			// n is box 0-3
-	invertColor(inv);
-	u8g2centerText(v, n*32, hline*2+3, 32, 22);
-}
-
-void dispGenericMode(int submode, int selected){
-	const char* legends[4] = {"","","",""};
-	int legendVals[4] = {0,0,0,0};
-	int dispPage = 0;
-	const char* legendText[4] = {"","","",""};
-//	int displaychan = sysSettings.midiChannel;
-	switch(submode){
-		case SUBMODE_MIDI:
-//			if (midiRoundRobin) {
-//				displaychan = rrChannel;
-//			}
-			legends[0] = "OCT";
-			legends[1] = "CH";
-			legends[2] = "CC";
-			legends[3] = "NOTE";
-			legendVals[0] = (int)octave+4;
-			legendVals[1] = sysSettings.midiChannel;
-			legendVals[2] = potVal;
-			legendVals[3] = midiLastNote;
-			dispPage = 1;
-			break;
-		case SUBMODE_MIDI2:
-			legends[0] = "RR";
-			legends[1] = "RROF";
-			legends[2] = "PGM";
-			legends[3] = "BNK";
-			legendVals[0] = midiRRChannelCount;
-			legendVals[1] = midiRRChannelOffset;
-			legendVals[2] = currpgm + 1;
-			legendVals[3] = currbank;
-			dispPage = 2;
-			break;
-		case SUBMODE_MIDI3:
-			legends[0] = "PBNK";	// Potentiometer Banks
-			legends[1] = "THRU";	// MIDI thru (usb to hardware)
-			legends[2] = "MCRO";	// Macro mode
-			legends[3] = "M-CH";
-			legendVals[0] = potbank + 1;
-			legendVals[1] = -127;
-			if (midiSoftThru) {
-				legendText[1] = "On";
-			} else {
-				legendText[1] = "Off";
-			}			
-			legendVals[2] = -127;
-			legendText[2] = macromodes[midiMacro];
-			legendVals[3] = midiMacroChan;
-			dispPage = 3;
-			break;
-		case SUBMODE_MIDI4:
-			legends[0] = " BG ";	
-			legends[1] = "---";
-			legends[2] = "---";
-			legends[3] = "---";
-			legendVals[0] = 0;
-			legendVals[1] = 0;
-			legendVals[2] = 0;
-			legendVals[3] = 0;
-			dispPage = 4;
-			break;
-		case SUBMODE_SEQ:
-			legends[0] = "PTN";
-			legends[1] = "TRSP";
-			legends[2] = "SWNG"; //"TRSP";
-			legends[3] = "BPM";
-			legendVals[0] = sequencer.playingPattern + 1;
-			legendVals[1] = (int)transpose;
-			legendVals[2] = (int)sequencer.getCurrentPattern()->swing; //(int)swing;
-			// legendVals[2] =  swing_values[sequencer.getCurrentPattern()->swing];
-			legendVals[3] = (int)clockbpm;
-			dispPage = 1;
-			break;
-		case SUBMODE_SEQ2:
-			legends[0] = "SOLO";
-			legends[1] = "LEN";
-			legends[2] = "RATE";
-			legends[3] = "CV"; //cvPattern
-			legendVals[0] = sequencer.getCurrentPattern()->solo; // playingPattern+1;
-			legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
-			legendVals[2] = -127;
-			legendText[2] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
-
-			legendVals[3] = -127;
-			if (sequencer.getCurrentPattern()->sendCV) {
-				legendText[3] = "On";
-			} else {
-				legendText[3] = "Off";
-			}
-			dispPage = 2;
-			break;
-		case SUBMODE_PATTPARAMS:
-			legends[0] = "PTN";
-			legends[1] = "LEN";
-			legends[2] = "ROT";
-			legends[3] = "CHAN";
-			legendVals[0] = sequencer.playingPattern + 1;
-			legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
-			legendVals[2] = rotationAmt; //(int)transpose;
-			legendVals[3] = sequencer.getPatternChannel(sequencer.playingPattern);
-			dispPage = 1;
-			break;
-		case SUBMODE_PATTPARAMS2:
-			legends[0] = "START";
-			legends[1] = "END";
-			legends[2] = "FREQ";
-			legends[3] = "PROB";
-			legendVals[0] = sequencer.getCurrentPattern()->startstep + 1;			// STRT step to autoreset on
-			legendVals[1] = sequencer.getCurrentPattern()->autoresetstep;			// STP step to autoreset on - 0 = no auto reset
-			legendVals[2] = sequencer.getCurrentPattern()->autoresetfreq; 			// FRQ to autoreset on -- every x cycles
-			legendVals[3] = sequencer.getCurrentPattern()->autoresetprob;			// PRO probability of resetting 0=NEVER 1=Always 2=50%
-			dispPage = 2;
-			break;
-		case SUBMODE_PATTPARAMS3:
-			legends[0] = "RATE";
-			legends[1] = "SOLO";
-			legends[2] = "---";
-			legends[3] = "---";
-
-			// RATE FOR CURR PATTERN
-			legendVals[0] = -127;
-			legendText[0] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
-
-			legendVals[1] = sequencer.getCurrentPattern()->solo;
-			legendVals[2] = 0; 			// TBD
-			legendVals[3] = 0;			// TBD
-			dispPage = 3;
-			break;
-		case SUBMODE_STEPREC:
-			legends[0] = "OCT";
-			legends[1] = "STEP";
-			legends[2] = "NOTE";
-			legends[3] = "PTN";
-			legendVals[0] = (int)octave+4;
-			legendVals[1] = sequencer.seqPos[sequencer.playingPattern]+1;
-			legendVals[2] = getSelectedStep()->note; //(int)transpose;
-			legendVals[3] = sequencer.playingPattern+1;
-			dispPage = 1;
-			break;
-		case SUBMODE_NOTESEL:
-			legends[0] = "NOTE";
-			legends[1] = "OCT";
-			legends[2] = "VEL";
-			legends[3] = "LEN";
-			legendVals[0] = getSelectedStep()->note;
-			legendVals[1] = (int)octave+4;
-			legendVals[2] = getSelectedStep()->vel;
-			legendVals[3] = getSelectedStep()->len + 1;
-			dispPage = 1;
-			break;
-		case SUBMODE_NOTESEL2:
-			legends[0] = "TYPE";
-			legends[1] = "PROB";
-			legends[2] = "COND";
-			legends[3] = "";
-			legendVals[0] = -127;
-			legendText[0] = stepTypes[getSelectedStep()->stepType];
-			legendVals[1] = getSelectedStep()->prob;
-//				String ac = String(trigConditionsAB[][0]);
-//				String bc = String(trigConditionsAB[getSelectedStep()->condition][1]);
-
-			legendVals[2] = -127;
-			legendText[2] = trigConditions[getSelectedStep()->condition]; //ac + bc; // trigConditions
-
-			legendVals[3] = 0;
-			dispPage = 2;
-			break;
-		case SUBMODE_NOTESEL3:
-			legends[0] = "L-1";
-			legends[1] = "L-2";
-			legends[2] = "L-3";
-			legends[3] = "L-4";
-			for (int j=0; j<4; j++){
-				int stepNoteParam = getSelectedStep()->params[j];
-				if (stepNoteParam > -1){
-					legendVals[j] = stepNoteParam;
-				} else {
-					legendVals[j] = -127;
-					legendText[j] = "---";
-				}
-			}
-			dispPage = 3;
-			break;
-
-		default:
-			break;
-	}
-
-
-	u8g2_display.setFontMode(1);
-	u8g2_display.setFont(FONT_LABELS);
-	u8g2_display.setCursor(0, 0);
-	dispGridBoxes();
-
-	// labels
-	u8g2_display.setForegroundColor(BLACK);
-	u8g2_display.setBackgroundColor(WHITE);
-
-	for (int j= 0; j<4; j++){
-		u8g2centerText(legends[j], (j*32) + 1, hline-2, 32, 10);
-	}
-
-	// value text formatting
-	u8g2_display.setFontMode(1);
-	u8g2_display.setFont(FONT_VALUES);
-	u8g2_display.setForegroundColor(WHITE);
-	u8g2_display.setBackgroundColor(BLACK);
-
-
-	switch(selected){
-		case 1:
-			display.fillRect(0*32+2, 9, 29, 21, WHITE);
-			break;
-		case 2: 	//
-			display.fillRect(1*32+2, 9, 29, 21, WHITE);
-			break;
-		case 3: 	//
-			display.fillRect(2*32+2, 9, 29, 21, WHITE);
-			break;
-		case 4: 	//
-			display.fillRect(3*32+2, 9, 29, 21, WHITE);
-			break;
-		case 0:
-		default:
-			break;
-	}
-	// ValueBoxes
-	int highlight = false;
-	for (int j = 1; j < NUM_DISP_PARAMS; j++){ // start at 1 to only highlight values 1-4
-
-		if (j == selected) {
-			highlight = true;
-		}else{
-			highlight = false;
-		}
-		if (legendVals[j-1] == -127){
-			dispSymbBox(legendText[j-1], j-1, highlight);
-		} else {
-			dispValBox(legendVals[j-1], j-1, highlight);
-		}
-	}
-	if (dispPage != 0) {
-		for (int k=0; k<4; k++){
-			if (dispPage == k+1){
-				dispPageIndicators(k, true);
-			} else {
-				dispPageIndicators(k, false);
-			}
-		}
-	}
-
-}
-
-void dispPageIndicators(int page, bool selected){
-	if (selected){
-		display.fillRect(43 + (page * 12), 30, 6, 2, WHITE);
-	} else {
-		display.fillRect(43 + (page * 12), 31, 6, 1, WHITE);
-	}
-}
-
-void dispMode(){
-	// labels formatting
-	u8g2_display.setFontMode(1);
-	u8g2_display.setFont(FONT_BIG);
-	u8g2_display.setCursor(0, 0);
-
-	u8g2_display.setForegroundColor(WHITE);
-	u8g2_display.setBackgroundColor(BLACK);
-
-	const char* displaymode = "";
-	if (sysSettings.newmode != sysSettings.omxMode && enc_edit) {
-		displaymode = modes[sysSettings.newmode]; // display.print(modes[sysSettings.newmode]);
-	} else if (enc_edit) {
-		displaymode = modes[sysSettings.omxMode]; // display.print(modes[mode]);
-	}
-	u8g2centerText(displaymode, 86, 20, 44, 32);
-}
 
 
 // ############## MAIN LOOP ##############
@@ -2427,7 +2051,7 @@ void midiNoteOn(int notenum, int velocity, int channel) {
 
 	strip.setPixelColor(notenum, MIDINOTEON);         //  Set pixel's color (in RAM)
 	dirtyPixels = true;
-	dirtyDisplay = true;
+	omxidsp.setDispDirty();
 }
 
 void midiNoteOff(int notenum, int channel) {
@@ -2443,27 +2067,10 @@ void midiNoteOff(int notenum, int channel) {
 	
 	strip.setPixelColor(notenum, LEDOFF);
 	dirtyPixels = true;
-	dirtyDisplay = true;
+	omxidsp.setDispDirty();
 }
 
-void u8g2centerText(const char* s, int16_t x, int16_t y, uint16_t w, uint16_t h) {
-//  int16_t bx, by;
-	uint16_t bw, bh;
-	bw = u8g2_display.getUTF8Width(s);
-	bh = u8g2_display.getFontAscent();
-	u8g2_display.setCursor(
-		x + (w - bw) / 2,
-		y + (h - bh) / 2
-	);
-	u8g2_display.print(s);
-}
 
-void u8g2centerNumber(int n, uint16_t x, uint16_t y, uint16_t w, uint16_t h)
-{
-	char buf[8];
-	itoa(n, buf, 10);
-	u8g2centerText(buf, x, y, w, h);
-}
 
 
 // #### LED STUFF
@@ -2594,35 +2201,9 @@ void RolandFill(byte red, byte green, byte blue, int start, int end, int SpeedDe
 }
 
 // #### OLED STUFF
-void testdrawrect(void) {
-	display.clearDisplay();
 
-	for(int16_t i=0; i<display.height()/2; i+=2) {
-		display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
-		display.display(); // Update screen with each newly-drawn rectangle
-		delay(1);
-	}
 
-	delay(500);
-}
 
-void drawLoading(void) {
-	const char* loader[] = {"\u25f0", "\u25f1", "\u25f2", "\u25f3"};
-	display.clearDisplay();
-	u8g2_display.setFontMode(0);
-	for(int16_t i=0; i<16; i+=1) {
-		display.clearDisplay();
-		u8g2_display.setCursor(18,18);
-		u8g2_display.setFont(FONT_TENFAT);
-		u8g2_display.print("OMX-27");
-		u8g2_display.setFont(FONT_SYMB_BIG);
-		u8g2centerText(loader[i%4], 80, 10, 32, 32); // "\u00BB\u00AB" // // dice: "\u2685"
-		display.display();
-		delay(100);
-	}
-
-	delay(100);
-}
 
 // TODO: move to sequencer.h
 void initPatterns( void ) {

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -80,9 +80,9 @@ int nspage = 0;
 // int pppage = 0;
 // int sqpage = 0;
 // int srpage = 0;
-int mmpage = 0;
+// int mmpage = 0;
 
-int miparam = 0;	// midi params item counter
+// int miparam = 0;	// midi params item counter
 // int nsparam = 0;	// note select params
 // int ppparam = 0;	// pattern params
 // int sqparam = 0;	// seq params

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -167,13 +167,6 @@ void setup()
 
 // ####### SEQUENCER LEDS #######
 
-void show_current_step(int patternNum)
-{
-	if(sysSettings.screenSaverMode && !sequencer.playing) return; // Screensaver active and not playing, don't update sequencer LEDs. 
-
-	omxModeSeq.showCurrentStep(patternNum);
-}
-
 void changeOmxMode(OMXMode newOmxmode)
 {
 	sysSettings.omxMode = newOmxmode;
@@ -611,6 +604,14 @@ void loadPatterns(void)
 
 		nLocalAddress += patternSize;
 	}
+
+	// Serial.println( "Pattern size" );
+	// Serial.println( patternSize );
+	// Pattern size = 715
+	// Total size of patterns = 5720
+	// Total storage size = 5749
+	// Fram = 32000 = 26251 available
+	// Eeprom = 2048
 }
 
 // currently saves everything ( mode + patterns )

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -1,5 +1,5 @@
 // OMX-27 MIDI KEYBOARD / SEQUENCER
-// v 1.6.0
+// v 1.7.0beta
 //
 // Steven Noreyko, Last update: July 2022
 //
@@ -8,7 +8,7 @@
 //	John Park and Gerald Stevens for initial testing and feature ideas
 //	mzero for immense amounts of code coaching/assistance
 //	drjohn for support
-//  Additional code contributions: Matt Boone, Steven Zydek, Chris Atkins, Will Winder
+//  Additional code contributions: Matt Boone, Steven Zydek, Chris Atkins, Will Winder, Michael P Jones
 
 #include <functional>
 #include <ResponsiveAnalogRead.h>

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -12,7 +12,7 @@
 
 
 #include <functional>
-#include <Adafruit_NeoPixel.h>
+// #include <Adafruit_NeoPixel.h>
 #include <ResponsiveAnalogRead.h>
 
 #include "consts.h"
@@ -28,8 +28,21 @@
 #include "omx_util.h"
 #include "omx_disp.h"
 
-const int potCount = 5;
-ResponsiveAnalogRead *analog[potCount];
+#include "omx_mode_midi_keyboard.h"
+#include "omx_mode_sequencer.h"
+#include "omx_screensaver.h"
+#include "omx_leds.h"
+
+
+
+OmxModeMidiKeyboard omxModeMidi;
+OmxModeMidiKeyboard omxModeOM;
+OmxModeSequencer omxModeS1;
+OmxModeSequencer omxModeS2;
+
+OmxModeInterface* activeOmxMode;
+
+OmxScreensaver omxScreensaver;
 
 // storage of pot values; current is in the main loop; last value is for midi output
 int volatile currentValue[potCount];
@@ -39,11 +52,10 @@ int potMax = 8190;
 int temp;
 
 // Timers and such
-elapsedMillis blink_msec = 0;
-elapsedMillis slow_blink_msec = 0;
+// elapsedMillis blink_msec = 0;
+// elapsedMillis slow_blink_msec = 0;
 elapsedMillis pots_msec = 0;
-elapsedMillis dirtyDisplayTimer = 0;
-unsigned long displayRefreshRate = 60;
+
 elapsedMicros clksTimer = 0;		// is this still in use?
 
 //unsigned long clksDelay;
@@ -56,80 +68,47 @@ volatile unsigned long noteon_micros;
 volatile unsigned long noteoff_micros;
 volatile unsigned long ppqInterval;
 
-elapsedMillis screenSaverCounter = 0;
-bool screenSaverMode = false;
-unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default? // 10000;  15000; //
-int ssstep = 0;
-int ssloop = 0;
-volatile unsigned long nextStepTimeSS = 0;
-bool ssreverse = false;
-int sleepTick = 80;
+
+// bool screenSaverMode = false;
+
+// int sleepTick = 80;
 
 // DEFAULT COLOR VARIABLES
-uint32_t screensaverColor = 0xFF0000;
-uint32_t stepColor = 0x000000;
-uint32_t muteColor = 0x000000;
-uint16_t midiBg_Hue = 0;
-uint8_t midiBg_Sat = 255;
-uint8_t midiBg_Brightness = 255;
+
 
 int nspage = 0;
-int pppage = 0;
-int sqpage = 0;
-int srpage = 0;
+// int pppage = 0;
+// int sqpage = 0;
+// int srpage = 0;
 int mmpage = 0;
 
 int miparam = 0;	// midi params item counter
-int nsparam = 0;	// note select params
-int ppparam = 0;	// pattern params
-int sqparam = 0;	// seq params
-int srparam = 0;	// step record params
+// int nsparam = 0;	// note select params
+// int ppparam = 0;	// pattern params
+// int sqparam = 0;	// seq params
+// int srparam = 0;	// step record params
 int tmpmmode = 9;
 
-// global sequencer shared state
-SequencerState sequencer = defaultSequencer();
-
 // VARIABLES / FLAGS
-float step_delay;
-bool dirtyPixels = false;
+// float step_delay;
+// bool dirtyPixels = false;
 
-bool blinkState = false;
-bool slowBlinkState = false;
-bool noteSelect = false;
-bool noteSelection = false;
-bool patternParams = false;
-bool seqPages = false;
+// bool blinkState = false;
+// bool slowBlinkState = false;
+
+// bool patternParams = false;
+// bool seqPages = false;
 int noteSelectPage = 0;
-int selectedNote = 0;
-int selectedStep = 0;
-bool stepSelect = false;
-bool stepRecord = false;
-bool stepDirty = false;
+
 bool dialogFlags[] = {false, false, false, false, false, false};
 unsigned dialogDuration = 1000;
-
-bool copiedFlag = false;
-bool pastedFlag = false;
-bool clearedFlag = false;
-
-bool enc_edit = false;
-bool midiAUX = false;
-
-bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
 
 int pitchCV;
 uint8_t RES;
 uint16_t AMAX;
 int V_scale;
 
-// clock
-float clockbpm = 120;
-float newtempo = clockbpm;
-unsigned long tempoStartTime, tempoEndTime;
-
-unsigned long blinkInterval = clockbpm * 2;
-
-
+// unsigned long blinkInterval = clockConfig.clockbpm * 2;
 
 //int midiChannel; // the MIDI channel number to send messages (MIDI/OM mode)
 
@@ -145,8 +124,8 @@ unsigned long longPressInterval = 800;
 unsigned long clickWindow = 200;
 OMXKeypad keypad(longPressInterval, clickWindow, makeKeymap(keys), rowPins, colPins, ROWS, COLS);
 
-// Declare NeoPixel strip object
-Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+// // Declare NeoPixel strip object
+// Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 
 // setup EEPROM/FRAM storage
 Storage* storage;
@@ -183,7 +162,7 @@ void advanceSteps(Micros advance) {
 
 void resetClocks(){
 	// BPM tempo to step_delay calculation
-	ppqInterval = 60000000/(PPQ * clockbpm); 		// ppq interval is in microseconds
+	ppqInterval = 60000000/(PPQ * clockConfig.clockbpm); 		// ppq interval is in microseconds
 	step_micros = ppqInterval * (PPQ/4); 			// 16th note step in microseconds (quarter of quarter note)
 
 	// 16th note step length in milliseconds
@@ -208,27 +187,27 @@ void setGlobalSwing(int swng_amt){
 void readPotentimeters(){
 	for(int k=0; k<potCount; k++) {
 		temp = analogRead(analogPins[k]);
-		analog[k]->update(temp);
+		potSettings.analog[k]->update(temp);
 
 		// read from the smoother, constrain (to account for tolerances), and map it
-		temp = analog[k]->getValue();
+		temp = potSettings.analog[k]->getValue();
 		temp = constrain(temp, potMin, potMax);
 		temp = map(temp, potMin, potMax, 0, 16383);
 
 		// map and update the value
-		analogValues[k] = temp >> 7;
+		potSettings.analogValues[k] = temp >> 7;
 
-		if(analog[k]->hasChanged()) {
+		if(potSettings.analog[k]->hasChanged()) {
 			 // do stuff
-			if (screenSaverMode){
-				screensaverColor = analog[4]->getValue() * 4;	// value is 0-32764 for strip.ColorHSV
-
-				// reset screensaver
-				if(analog[0]->hasChanged() || analog[1]->hasChanged() || analog[2]->hasChanged() || analog[3]->hasChanged()) { 
-					screenSaverCounter = 0;
-				}
+			if (sysSettings.screenSaverMode){
+				omxScreensaver.OnPotChanged(k, potSettings.analogValues[k]);
 			}
-			
+			else { // don't send pots in screensaver
+			{
+				activeOmxMode->OnPotChanged(k, potSettings.analogValues[k]);
+			}
+
+/*
 			switch(sysSettings.omxMode) {
 				case MODE_OM:
 						// fall through - same as MIDI
@@ -278,6 +257,7 @@ void readPotentimeters(){
 					break;
 				}
 			}
+			*/
 	}
 }
 
@@ -312,17 +292,19 @@ void setup() {
 
 	// initialize ResponsiveAnalogRead
 	for (int i = 0; i < potCount; i++){
-		analog[i] = new ResponsiveAnalogRead(0, true, .001);
-		analog[i]->setAnalogResolution(1 << 13);
+		potSettings.analog[i] = new ResponsiveAnalogRead(0, true, .001);
+		potSettings.analog[i]->setAnalogResolution(1 << 13);
 
 		// ResponsiveAnalogRead is designed for 10-bit ADCs
 		// meanining its threshold defaults to 4. Let's bump that for
 		// our 13-bit adc by setting it to 4 << (13-10)
-		analog[i]->setActivityThreshold(32);
+		potSettings.analog[i]->setActivityThreshold(32);
 
 		currentValue[i] = 0;
 		lastMidiValue[i] = 0;
 	}
+
+	activeOmxMode = &omxModeMidi;
 
 	// HW MIDI
 	MM::begin();
@@ -466,7 +448,7 @@ void midi_leds() {
 		strip.setPixelColor(0, LEDOFF);
 		
 		// Other keys
-		if (!screenSaverMode){
+		if (!sysSettings.screenSaverMode){
 			// clear not held leds
 			for (int q = 1; q < LED_COUNT; q++){				
 				if (midiKeyState[q] == -1){
@@ -487,6 +469,11 @@ void midi_leds() {
 // ####### SEQUENCER LEDS #######
 
 void show_current_step(int patternNum) {
+	omxLeds.updateLeds();
+
+	omxModeS1.showCurrentStep(patternNum);
+
+	/*
 	blinkInterval = step_delay*2;
 	unsigned long slowBlinkInterval = blinkInterval * 2;
 
@@ -498,288 +485,9 @@ void show_current_step(int patternNum) {
 		slowBlinkState = !slowBlinkState;
 		slow_blink_msec = 0;
 	}
-
-
-	// AUX KEY
-
-	if (sequencer.playing && blinkState) {
-		strip.setPixelColor(0, WHITE);
-	} else if (noteSelect && blinkState){
-		strip.setPixelColor(0, NOTESEL);
-	} else if (patternParams && blinkState){
-		strip.setPixelColor(0, seqColors[patternNum]);
-	} else if (stepRecord && blinkState){
-		strip.setPixelColor(0, seqColors[patternNum]);
-	} else {
-		switch(sysSettings.omxMode){
-			case MODE_S1:
-				strip.setPixelColor(0, SEQ1C);
-				break;
-			case MODE_S2:
-				strip.setPixelColor(0, SEQ2C);
-				break;
-			default:
-				strip.setPixelColor(0, LEDOFF);
-				break;
-		}
-	}
-
-	if (sequencer.getPattern(patternNum)->mute) {
-		stepColor = muteColors[patternNum];
-	} else {
-		stepColor = seqColors[patternNum];
-		muteColor = muteColors[patternNum];
-	}
-
-	auto currentpage = sequencer.patternPage[patternNum];
-	auto pagestepstart = (currentpage * NUM_STEPKEYS);
-
-	if (noteSelect && noteSelection) {
-		// 27 LEDS so use LED_COUNT
-		for(int j = 1; j < LED_COUNT; j++){
-			auto pixelpos = j;
-			auto selectedStepPixel = (selectedStep % NUM_STEPKEYS) + 11;
-
-			if (pixelpos == selectedNote){
-				strip.setPixelColor(pixelpos, HALFWHITE);
-			} else if (pixelpos == selectedStepPixel){
-				strip.setPixelColor(pixelpos, SEQSTEP);
-			} else{
-				strip.setPixelColor(pixelpos, LEDOFF);
-			}
-
-			// Blink left/right keys for octave select indicators.
-			auto color1 = blinkState ? ORANGE : WHITE;
-			auto color2 = blinkState ? RBLUE : WHITE;
-			strip.setPixelColor(11, color1);
-			strip.setPixelColor(26, color2);
-		}
-
-	} else if (stepRecord) {		// STEP RECORD
-//		int numPages = ceil(float(sequencer.getPatternLength(patternNum))/float(NUM_STEPKEYS));
-
-		// BLANK THE TOP ROW
-		for(int j = 1; j < LED_COUNT - NUM_STEPKEYS; j++){
-			strip.setPixelColor(j, LEDOFF);
-		}
-
-		for(int j = pagestepstart; j < (pagestepstart + NUM_STEPKEYS); j++){
-			auto pixelpos = j - pagestepstart + 11;
-//			if (j < sequencer.getPatternLength(patternNum)){
-				// ONLY DO LEDS FOR THE CURRENT PAGE
-				if (j == sequencer.seqPos[sequencer.playingPattern]){
-					strip.setPixelColor(pixelpos, SEQCHASE);
-				} else if (pixelpos != selectedNote){
-					strip.setPixelColor(pixelpos, LEDOFF);
-				}
-//			} else  {
-//				strip.setPixelColor(pixelpos, LEDOFF);
-//			}
-		}
-
-	} else if (sequencer.getCurrentPattern()->solo){			// MIDI SOLO
-
-//		for(int i = 0; i < NUM_STEPKEYS; i++){
-//			if (i == seqPos[patternNum]){
-//				if (playing){
-//					strip.setPixelColor(i+11, SEQCHASE); // step chase
-//				} else {
-//					strip.setPixelColor(i+11, LEDOFF);  // DO WE NEED TO MARK PLAYHEAD WHEN STOPPED?
-//				}
-//			} else {
-//				strip.setPixelColor(i+11, LEDOFF);
-//			}
-//		}
-	} else if (seqPages){
-		// BLINK F1+F2
-		auto color1 = blinkState ? FUNKONE : LEDOFF;
-		auto color2 = blinkState ? FUNKTWO : LEDOFF;
-		strip.setPixelColor(1, color1);
-		strip.setPixelColor(2, color2);
-
-		// TURN OFF LEDS
-		// 27 LEDS so use LED_COUNT
-		for(int j = 3; j < LED_COUNT; j++){  // START WITH LEDS AFTER F-KEYS
-			strip.setPixelColor(j, LEDOFF);
-		}
-		// SHOW LEDS FOR WHAT PAGE OF SEQ PATTERN YOURE ON
-		auto len = (sequencer.getPattern(patternNum)->len/NUM_STEPKEYS);
-		for(int h = 0; h <= len; h++){
-			auto currentpage = sequencer.patternPage[patternNum];
-			auto color = sequencePageColors[h];
-			if (h == currentpage){
-				color = blinkState ? sequencePageColors[currentpage] : LEDOFF;
-			}
-			strip.setPixelColor(11 + h, color);
-		}
-	} else {
-		for(int j = 1; j < LED_COUNT; j++){
-			if (j < sequencer.getPatternLength(patternNum)+11){
-				if (j == 1) {
-															// NOTE SELECT / F1
-					if (keyState[j] && blinkState){
-						strip.setPixelColor(j, LEDOFF);
-					} else {
-						strip.setPixelColor(j, FUNKONE);
-					}
-				} else if (j == 2) {
-															// PATTERN PARAMS / F2
-					if (keyState[j] && blinkState){
-						strip.setPixelColor(j, LEDOFF);
-					} else {
-						strip.setPixelColor(j, FUNKTWO);
-					}
-
-				} else if (j == patternNum+3){  			// PATTERN SELECT
-					strip.setPixelColor(j, stepColor);
-					if (patternParams && blinkState){
-						strip.setPixelColor(j, LEDOFF);
-					}
-				} else {
-					strip.setPixelColor(j, LEDOFF);
-				}
-			} else {
-				strip.setPixelColor(j, LEDOFF);
-			}
-		}
-
-		auto pattern = sequencer.getPattern(patternNum);
-		auto steps = pattern->steps;
-		auto currentpage = sequencer.patternPage[patternNum];
-		auto pagestepstart = (currentpage * NUM_STEPKEYS);
-
-		// WHAT TO DO HERE FOR MULTIPLE PAGES
-		// NUM_STEPKEYS or NUM_STEPS INSTEAD?
-		for(int i = pagestepstart; i < (pagestepstart + NUM_STEPKEYS); i++){
-			if (i < sequencer.getPatternLength(patternNum)){
-
-				// ONLY DO LEDS FOR THE CURRENT PAGE
-				auto pixelpos = i - pagestepstart + 11;
-//				if (patternParams){
-// 					strip.setPixelColor(pixelpos, SEQMARKER);
-// 				}
-
-				if(i % 4 == 0){ 					// MARK GROUPS OF 4
-					if(i == sequencer.seqPos[patternNum]){
-						if (sequencer.playing){
-							strip.setPixelColor(pixelpos, SEQCHASE); // step chase
-						} else if (steps[i].trig == TRIGTYPE_PLAY){
-							if (steps[i].stepType != STEPTYPE_NONE){
-								if (slowBlinkState){
-									strip.setPixelColor(pixelpos, stepColor); // STEP EVENT COLOR
-								}else{
-									strip.setPixelColor(pixelpos, muteColor); // STEP EVENT COLOR
-								}
-							} else {
-								strip.setPixelColor(pixelpos, stepColor); // STEP ON COLOR
-							}
-						} else if (steps[i].trig == TRIGTYPE_MUTE){
-							strip.setPixelColor(pixelpos, SEQMARKER);
-						}
-					} else if (steps[i].trig == TRIGTYPE_PLAY) {
-						if (steps[i].stepType != STEPTYPE_NONE){
-							if (slowBlinkState){
-								strip.setPixelColor(pixelpos, stepColor); // STEP EVENT COLOR
-							}else{
-								strip.setPixelColor(pixelpos, muteColor); // STEP EVENT COLOR
-							}
-						} else {
-							strip.setPixelColor(pixelpos, stepColor); // STEP ON COLOR
-						}
-					} else if (steps[i].trig == TRIGTYPE_MUTE){
-						strip.setPixelColor(pixelpos, SEQMARKER);
-					}
-
-				} else if (i == sequencer.seqPos[patternNum]){ 		// STEP CHASE
-					if (sequencer.playing){
-						strip.setPixelColor(pixelpos, SEQCHASE);
-
-					} else if (steps[i].trig == TRIGTYPE_PLAY){
-						if (steps[i].stepType != STEPTYPE_NONE){
-							if (slowBlinkState){
-								strip.setPixelColor(pixelpos, stepColor); // STEP EVENT COLOR
-							}else{
-								strip.setPixelColor(pixelpos, muteColor); // STEP EVENT COLOR
-							}
-						} else {
-							strip.setPixelColor(pixelpos, stepColor); // STEP ON COLOR
-						}
-					} else if (!patternParams && sequencer.patterns[patternNum].steps[i].trig == TRIGTYPE_MUTE){
-						strip.setPixelColor(pixelpos, LEDOFF);  // DO WE NEED TO MARK PLAYHEAD WHEN STOPPED?
-					} else if (patternParams){
-						strip.setPixelColor(pixelpos, SEQMARKER);
-					}
-				}
-				else if (steps[i].trig == TRIGTYPE_PLAY)
-				{
-					if (steps[i].stepType != STEPTYPE_NONE){
-						if (slowBlinkState){
-							strip.setPixelColor(pixelpos, stepColor); // STEP EVENT COLOR
-						}else{
-							strip.setPixelColor(pixelpos, muteColor); // STEP EVENT COLOR
-						}
-					} else {
-						strip.setPixelColor(pixelpos, stepColor); // STEP ON COLOR
-					}
-
-				} else if (!patternParams && steps[i].trig == TRIGTYPE_MUTE){
-					strip.setPixelColor(pixelpos, LEDOFF);
-				} else if (patternParams){
-					strip.setPixelColor(pixelpos, SEQMARKER);
-				}
-			}
-		}
-	}
-	dirtyPixels = true;
-//	strip.show();
+	*/
 }
 
-// SLEEP MODE LEDS
-void sleepModeOne(){
-	unsigned long playstepmillis = millis();
-	if (playstepmillis > nextStepTimeSS){ 
-		ssstep = ssstep % 16;
-		ssloop = ssloop % 16 ;
-	
-		int j = 26 - ssloop;
-		int i = ssstep + 11;
-
-		for (int z=1; z<11; z++){
-			strip.setPixelColor(z, 0);
-		}
-		if (!ssreverse) {
-			// turn off all leds
-			for (int x=0; x<16; x++){
-				if (i < j){
-					strip.setPixelColor(x+11, 0);
-				}
-				if (x+11 > j){
-					strip.setPixelColor(x+11, strip.gamma32(strip.ColorHSV(screensaverColor)));
-				}
-			}
-			strip.setPixelColor(i+1, strip.gamma32(strip.ColorHSV(screensaverColor)));
-		} else {
-			for (int y=0; y<16; y++){
-				if (i >= j){
-					strip.setPixelColor(y+11, 0);
-				}
-				if (y+11 < j){
-					strip.setPixelColor(y+11, strip.gamma32(strip.ColorHSV(screensaverColor)));
-				}
-			}
-			strip.setPixelColor(i+1, strip.gamma32(strip.ColorHSV(screensaverColor)));
-		}
-		ssstep++;
-		if (ssstep == 16){
-			ssloop++;
-		}
-		if (ssloop == 16){
-			ssreverse = !ssreverse;
-		}
-		nextStepTimeSS = nextStepTimeSS + sleepTick;
-		dirtyPixels = true;
-	}
-}
 // ####### END LEDS
 
 
@@ -797,9 +505,11 @@ void loop() {
 	Micros passed = now - lastProcessTime;
 	lastProcessTime = now;
 
+	sysSettings.timeElasped = passed;
+
 	if (passed > 0) {
 		if (sequencer.playing){
-			screenSaverCounter = 0;
+			omxScreensaver.resetCounter(); // screenSaverCounter = 0;
 			advanceClock(passed);
 			advanceSteps(passed);
 		}
@@ -812,19 +522,8 @@ void loop() {
 	// ############### SLEEP MODE ###############
 	//
 //	Serial.println(screenSaverCounter);
-	if (screenSaverCounter > screensaverInterval ){
-		screenSaverMode = true;
-	} else if (screenSaverCounter < 10){
-		ssstep = 0;
-		ssloop = 0;
-//		setAllLEDS(0,0,0);
-		screenSaverMode = false;
-		nextStepTimeSS = millis();
-	} else {
-		screenSaverMode = false;
-		nextStepTimeSS = millis();
-	}
-
+	omxScreensaver.updateScreenSaverState();
+	sysSettings.screenSaverMode = omxScreensaver.shouldShowScreenSaver();
 
 	// ############### POTS ###############
 	//
@@ -832,12 +531,12 @@ void loop() {
 
 
 	// ############### EXTERNAL MODE CHANGE / SYSEX ###############
-	if ((!enc_edit && (sysSettings.omxMode != sysSettings.newmode)) || sysSettings.refresh){
+	if ((!encoderConfig.enc_edit && (sysSettings.omxMode != sysSettings.newmode)) || sysSettings.refresh){
 		sysSettings.newmode = sysSettings.omxMode;
 		sequencer.playingPattern = sysSettings.playingPattern;
-		dirtyDisplay = true;
+		omxDisp.setDirty();
 		setAllLEDS(0,0,0);
-		dirtyPixels = true;
+		omxLeds.setDirty();
 		sysSettings.refresh = false;
 	}
 
@@ -847,338 +546,21 @@ void loop() {
 	auto u = myEncoder.update();
 	if (u.active()) {
 		auto amt = u.accel(5); // where 5 is the acceleration factor if you want it, 0 if you don't)
-		screenSaverCounter = 0;
+		omxScreensaver.resetCounter(); // screenSaverCounter = 0;
 //    	Serial.println(u.dir() < 0 ? "ccw " : "cw ");
 //    	Serial.println(amt);
 
 		// Change Mode
-		if (enc_edit) {
+		if (encoderConfig.enc_edit) {
 			// set mode
 //			int modesize = NUM_OMX_MODES;
 			sysSettings.newmode = (OMXMode)constrain(sysSettings.newmode + amt, 0, NUM_OMX_MODES - 1);
-			dispMode();
-			dirtyDisplayTimer = displayRefreshRate+1;
-			dirtyDisplay = true;
-
-		} else if (!noteSelect && !patternParams && !stepRecord){
-			switch(sysSettings.omxMode) {
-				case MODE_OM: // Organelle Mother
-					// CHANGE PAGE
-					if (miparam == 0) {
-						if(u.dir() < 0){									// if turn ccw
-							MM::sendControlChange(CC_OM2, 0, sysSettings.midiChannel);
-						} else if (u.dir() > 0){							// if turn cw
-							MM::sendControlChange(CC_OM2, 127, sysSettings.midiChannel);
-						}
-					}
-					dirtyDisplay = true;
-//					break;
-				case MODE_MIDI: // MIDI
-					if (midiAUX){
-						// change MIDI Background Color
-						// midiBg_Hue = constrain(midiBg_Hue + (amt * 32), 0, 65534); // 65535 
-						break;
-					}
-					// CHANGE PAGE
-					if (miparam == 0 || miparam == 5 || miparam == 10) {
-						mmpage = constrain(mmpage + amt, 0, 2);
-						miparam = mmpage * NUM_DISP_PARAMS;
-					}
-					// PAGE ONE
-					if (miparam == 2) {
-						int newchan = constrain(sysSettings.midiChannel + amt, 1, 16);
-						if (newchan != sysSettings.midiChannel){
-							sysSettings.midiChannel = newchan;
-						}
-					} else if (miparam == 1){
-						// set octave
-						newoctave = constrain(octave + amt, -5, 4);
-						if (newoctave != octave){
-							octave = newoctave;
-						}
-					}
-					// PAGE TWO
-					if (miparam == 6) {
-						int newrrchan = constrain(midiRRChannelCount + amt, 1, 16);
-						if (newrrchan != midiRRChannelCount){
-							midiRRChannelCount = newrrchan;
-							if (midiRRChannelCount == 1){
-								midiRoundRobin = false;
-							}else{
-								midiRoundRobin = true;
-							}
-						}
-					} else if (miparam == 7){
-						midiRRChannelOffset = constrain(midiRRChannelOffset + amt, 0, 15);
-					} else if (miparam == 8){
-						currpgm = constrain(currpgm + amt, 0, 127);
-
-						if (midiRoundRobin){
-							for (int q = midiRRChannelOffset+1 ; q < midiRRChannelOffset + midiRRChannelCount+1; q++){
-								MM::sendProgramChange(currpgm, q);
-							}
-						} else {
-							MM::sendProgramChange(currpgm, sysSettings.midiChannel);
-						}
-
-					} else if (miparam == 9){
-						currbank = constrain(currbank + amt, 0, 127);
-						// Bank Select is 2 mesages
-						MM::sendControlChange(0, 0, sysSettings.midiChannel);
-						MM::sendControlChange(32, currbank, sysSettings.midiChannel);
-						MM::sendProgramChange(currpgm, sysSettings.midiChannel);
-					}
-					// PAGE THREE
-					if (miparam == 11) {
-						potbank = constrain(potbank + amt, 0, NUM_CC_BANKS-1);
-					}
-					if (miparam == 12) {
-						midiSoftThru = constrain(midiSoftThru + amt, 0, 1);
-					}
-					if (miparam == 13) {
-						midiMacro = constrain(midiMacro + amt, 0, nummacromodes);
-					}
-					if (miparam == 14) {
-						midiMacroChan = constrain(midiMacroChan + amt, 1, 16);
-					}
-
-
-					dirtyDisplay = true;
-					break;
-				case MODE_S1: // SEQ 1
-					// FALL THROUGH
-				case MODE_S2: // SEQ 2
-					// CHANGE PAGE
-					if (sqparam == 0 || sqparam == 5 ) {
-						sqpage = constrain(sqpage + amt, 0, 1);
-						sqparam = sqpage * NUM_DISP_PARAMS;
-					}
-
-					// PAGE ONE
-					if (sqparam == 1){
-						sequencer.playingPattern = constrain(sequencer.playingPattern + amt, 0, 7);
-						if (sequencer.getCurrentPattern()->solo) {
-							setAllLEDS(0,0,0);
-						}
-					} else if (sqparam == 2){		// SET TRANSPOSE
-						transposeSeq(sequencer.playingPattern, amt); //
-						int newtransp = constrain(transpose + amt, -64, 63);
-						transpose = newtransp;
-					} else if (sqparam == 3){		// SET SWING
-						int newswing = constrain(sequencer.getCurrentPattern()->swing + amt, 0, maxswing - 1); // -1 to deal with display values
-						swing = newswing;
-						sequencer.getCurrentPattern()->swing = newswing;
-						//	setGlobalSwing(newswing);
-					} else if (sqparam == 4){		// SET TEMPO
-						newtempo = constrain(clockbpm + amt, 40, 300);
-						if (newtempo != clockbpm){
-							// SET TEMPO HERE
-							clockbpm = newtempo;
-							resetClocks();
-						}
-					}
-
-					// PAGE TWO
-					if (sqparam == 6){				//  MIDI SOLO
-//						playingPattern = constrain(playingPattern + amt, 0, 7);
-						sequencer.getCurrentPattern()->solo = constrain(sequencer.getCurrentPattern()->solo + amt, 0, 1);
-						if (sequencer.getCurrentPattern()->solo)
-						{
-							setAllLEDS(0,0,0);
-						}
-					} else if (sqparam == 7){		// SET PATTERN LENGTH
-						auto newPatternLen = constrain(sequencer.getPatternLength(sequencer.playingPattern) + amt, 1, NUM_STEPS);
-						sequencer.setPatternLength( sequencer.playingPattern, newPatternLen);
-						if (sequencer.seqPos[sequencer.playingPattern] >= newPatternLen){
-							sequencer.seqPos[sequencer.playingPattern] = newPatternLen-1;
-							sequencer.patternPage[sequencer.playingPattern] = getPatternPage(sequencer.seqPos[sequencer.playingPattern]);
-						}
-					} else if (sqparam == 8){		// SET CLOCK DIV/MULT
-						sequencer.getCurrentPattern()->clockDivMultP = constrain(sequencer.getCurrentPattern()->clockDivMultP + amt, 0, NUM_MULTDIVS - 1);
-					} else if (sqparam == 9){		// SET CV ON/OFF
-						sequencer.getCurrentPattern()->sendCV = constrain(sequencer.getCurrentPattern()->sendCV + amt, 0, 1);
-					}
-					dirtyDisplay = true;
-					break;
-				default:
-					break;
-			}
-
-		} else if (noteSelect || patternParams || stepRecord) {
-			switch(sysSettings.omxMode) { // process encoder input depending on mode
-				case MODE_MIDI: // MIDI
-					break;
-				case MODE_S1: // SEQ 1
-						// FALL THROUGH
-
-				case MODE_S2: // SEQ 2
-					if (patternParams && !enc_edit){ 		// SEQUENCE PATTERN PARAMS SUB MODE
-						//CHANGE PAGE
-						if (ppparam == 0 || ppparam == 5 || ppparam == 10) {
-							pppage = constrain(pppage + amt, 0, 2);		// HARDCODED - FIX WITH SIZE OF PAGES?
-							ppparam = pppage * NUM_DISP_PARAMS;
-						}
-
-						// PAGE ONE
-						if (ppparam == 1) { 					// SET PLAYING PATTERN
-							sequencer.playingPattern = constrain(sequencer.playingPattern + amt, 0, 7);
-						}
-						if (ppparam == 2) { 					// SET LENGTH
-							auto newPatternLen = constrain(sequencer.getPatternLength(sequencer.playingPattern) + amt, 1, NUM_STEPS);
-							sequencer.setPatternLength(sequencer.playingPattern, newPatternLen);
-							if (sequencer.seqPos[sequencer.playingPattern] >= newPatternLen){
-								sequencer.seqPos[sequencer.playingPattern] = newPatternLen-1;
-								sequencer.patternPage[sequencer.playingPattern] = getPatternPage(sequencer.seqPos[sequencer.playingPattern]);
-							}
-						}
-						if (ppparam == 3) { 					// SET PATTERN ROTATION
-							int rotator;
-							(u.dir() < 0 ? rotator = -1 : rotator = 1);
-//							int rotator = constrain(rotcc, (sequencer.PatternLength(sequencer.playingPattern))*-1, sequencer.PatternLength(sequencer.playingPattern));
-							rotationAmt = rotationAmt + rotator;
-							if (rotationAmt < 16 && rotationAmt > -16 ){ // NUM_STEPS??
-								rotatePattern(sequencer.playingPattern, rotator);
-							}
-							rotationAmt = constrain(rotationAmt, (sequencer.getPatternLength(sequencer.playingPattern) - 1) * -1, sequencer.getPatternLength(sequencer.playingPattern) - 1);
-						}
-
-						if (ppparam == 4) { 					// SET PATTERN CHANNEL
-							sequencer.getCurrentPattern()->channel = constrain(sequencer.getCurrentPattern()->channel + amt, 0, 15);
-						}
-						// PATTERN PARAMS PAGE 2
-							//TODO: convert to case statement ??
-						if (ppparam == 6) { 					// SET AUTO START STEP
-							sequencer.getCurrentPattern()->startstep = constrain(sequencer.getCurrentPattern()->startstep + amt, 0, sequencer.getCurrentPattern()->len);
-							//sequencer.getCurrentPattern()->startstep--;
-						}
-						if (ppparam == 7) { 					// SET AUTO RESET STEP
-							int tempresetstep = sequencer.getCurrentPattern()->autoresetstep + amt;
-							sequencer.getCurrentPattern()->autoresetstep = constrain(tempresetstep, 0, sequencer.getCurrentPattern()->len+1);
-						}
-						if (ppparam == 8) { 					// SET AUTO RESET FREQUENCY
-							sequencer.getCurrentPattern()->autoresetfreq = constrain(sequencer.getCurrentPattern()->autoresetfreq + amt, 0, 15); // max every 16 times
-						}
-						if (ppparam == 9) { 					// SET AUTO RESET PROB
-							sequencer.getCurrentPattern()->autoresetprob = constrain(sequencer.getCurrentPattern()->autoresetprob + amt, 0, 100); // never, 100% - 33%
-						}
-
-						// PAGE THREE
-						if (ppparam == 11) { 					// SET CLOCK-DIV-MULT
-							sequencer.getCurrentPattern()->clockDivMultP = constrain(sequencer.getCurrentPattern()->clockDivMultP + amt, 0, NUM_MULTDIVS - 1); // set clock div/mult
-						}
-						if (ppparam == 12) { 					// SET MIDI SOLO
-							sequencer.getCurrentPattern()->solo = constrain(sequencer.getCurrentPattern()->solo + amt, 0, 1);
-						}
-
-					// STEP RECORD SUB MODE
-					} else if (stepRecord && !enc_edit){
-						// CHANGE PAGE
-						if (srparam == 0 || srparam == 5) {
-							srpage = constrain(srpage + amt, 0, 1);		// HARDCODED - FIX WITH SIZE OF PAGES?
-							srparam = srpage * NUM_DISP_PARAMS;
-						}
-
-						// PAGE ONE
-						if (srparam == 1) {		// OCTAVE SELECTION
-							newoctave = constrain(octave + amt, -5, 4);
-							if (newoctave != octave){
-								octave = newoctave;
-							}
-						}
-						if (srparam == 2) {		// STEP SELECTION
-							if (u.dir() > 0){
-								step_ahead();
-							} else if (u.dir() < 0) {
-								step_back();
-							}
-							selectedStep = sequencer.seqPos[sequencer.playingPattern];
-						}
-						if (srparam == 3) {		// SET NOTE NUM
-							int tempNote = getSelectedStep()->note;
-							getSelectedStep()->note = constrain(tempNote + amt, 0, 127);
-						}
-						if (srparam == 4) {
-//							playingPattern = constrain(playingPattern + amt, 0, 7);
-						}
-						// PAGE TWO
-						if (srparam == 6) {		// STEP TYPE
-							changeStepType(amt);
-						}
-						if (srparam == 7) {		// STEP PROB
-							int tempProb = getSelectedStep()->prob;
-							getSelectedStep()->prob = constrain(tempProb + amt, 0, 100); // Note Len between 1-16
-						}
-						if (srparam == 8) {		// STEP CONDITION
-							int tempCondition = getSelectedStep()->condition;
-							getSelectedStep()->condition = constrain(tempCondition + amt, 0, 35); // 0-32
-						}
-
-					// NOTE SELECT MODE
-					} else if (noteSelect && noteSelection && !enc_edit){
-						// CHANGE PAGE
-						if (nsparam == 0 || nsparam == 5 || nsparam == 10) {
-							nspage = constrain(nspage + amt, 0, 2);		// HARDCODED - FIX WITH SIZE OF PAGES?
-							nsparam = nspage * NUM_DISP_PARAMS;
-						}
-
-						// PAGE THREE
-						if (nsparam > 10 && nsparam < 14){
-							if(u.dir() < 0){			// RESET PLOCK IF TURN CCW
-								int tempmode = nsparam - 11;
-								getSelectedStep()->params[tempmode] = -1;
-							}
-						}
-						// PAGE ONE
-						if (nsparam == 1) {				// SET NOTE NUM
-							int tempNote = getSelectedStep()->note;
-							getSelectedStep()->note = constrain(tempNote + amt, 0, 127);
-						}
-						if (nsparam == 2) { 				// SET OCTAVE
-							newoctave = constrain(octave + amt, -5, 4);
-							if (newoctave != octave){
-								octave = newoctave;
-							}
-						}
-						if (nsparam == 3) { 				// SET VELOCITY
-							int tempVel = getSelectedStep()->vel;
-							getSelectedStep()->vel = constrain(tempVel + amt, 0, 127);
-						}
-						if (nsparam == 4) { 				// SET NOTE LENGTH
-							int tempLen = getSelectedStep()->len;
-							getSelectedStep()->len = constrain(tempLen + amt, 0, 15); // Note Len between 1-16
-						}
-						// PAGE TWO
-						if (nsparam == 6) { 				// SET STEP TYPE
-							changeStepType(amt);
-						}
-						if (nsparam == 7) { 				// SET STEP PROB
-							int tempProb = getSelectedStep()->prob;
-							getSelectedStep()->prob = constrain(tempProb + amt, 0, 100); // Note Len between 1-16
-						}
-						if (nsparam == 8) { 				// SET STEP TRIG CONDITION
-							int tempCondition = getSelectedStep()->condition;
-							getSelectedStep()->condition = constrain(tempCondition + amt, 0, 35); // 0-32
-						}
-
-
-					} else {
-						newtempo = constrain(clockbpm + amt, 40, 300);
-						if (newtempo != clockbpm){
-							// SET TEMPO HERE
-							clockbpm = newtempo;
-							resetClocks();
-						}
-					}
-					dirtyDisplay = true;
-					break;
-
-				case MODE_OM: // Organelle Mother
-					break;
-
-				default:
-					break;
-			}
-		}
+			omxDisp.dispMode();
+			omxDisp.bumpDisplayTimer();
+			omxDisp.setDirty();
+		} else {
+			activeOmxMode->onEncoderChanged(u);
+		} 
 	}
 	// END ENCODER
 
@@ -1188,86 +570,43 @@ void loop() {
 	switch (s) {
 		// SHORT PRESS
 		case Button::Down: //Serial.println("Button down");
-			screenSaverCounter = 0;
+			omxScreensaver.resetCounter(); // screenSaverCounter = 0;
 			
 			// what page are we on?
-			if (sysSettings.newmode != sysSettings.omxMode && enc_edit) {
+			if (sysSettings.newmode != sysSettings.omxMode && encoderConfig.enc_edit) {
 				sysSettings.omxMode = sysSettings.newmode;
 				seqStop();
-				setAllLEDS(0,0,0);
-				enc_edit = false;
-				dispMode();
-			} else if (enc_edit){
-				enc_edit = false;
+				omxLeds.setAllLEDS(0,0,0);
+				encoderConfig.enc_edit = false;
+				omxDisp.dispMode();
+			} else if (encoderConfig.enc_edit){
+				encoderConfig.enc_edit = false;
 			}
 
-			if(sysSettings.omxMode == MODE_MIDI) {
-				// switch midi oct/chan selection
-				miparam = (miparam + 1 ) % 15;
-				mmpage = miparam / NUM_DISP_PARAMS;
-			}
-			if(sysSettings.omxMode == MODE_OM) {
-				miparam = (miparam + 1 ) % NUM_DISP_PARAMS;
-//				MM::sendControlChange(CC_OM1,100,sysSettings.midiChannel);
-			}
-			if(sysSettings.omxMode == MODE_S1 || sysSettings.omxMode == MODE_S2) {
-				if (noteSelect && noteSelection && !patternParams) {
-					nsparam = (nsparam + 1 ) % 15;
-					if (nsparam > 9){
-						nspage = 2;
-					}else if (nsparam > 4){
-						nspage = 1;
-					}else{
-						nspage = 0;
-					}
-				} else if (patternParams) {
-					ppparam = (ppparam + 1 ) % 15;
-					if (ppparam > 9){
-						pppage = 2;
-					}else if (ppparam > 4){
-						pppage = 1;
-					}else{
-						pppage = 0;
-					}
-				} else if (stepRecord) {
-					srparam = (srparam + 1 ) % 10;
-					if (srparam > 4){
-						srpage = 1;
-					}else{
-						srpage = 0;
-					}
+			activeOmxMode->onEncoderButtonDown();
 
-				} else {
-					sqparam = (sqparam + 1 ) % 10;
-					if (sqparam > 4){
-						sqpage = 1;
-					}else{
-						sqpage = 0;
-					}
-				}
-			}
-			dirtyDisplay = true;
+			omxDisp.setDirty();
 			break;
 
 		// LONG PRESS
 		case Button::DownLong: //Serial.println("Button downlong");
-			if (stepRecord) {
-				resetPatternDefaults(sequencer.playingPattern);
-				clearedFlag = true;
-			} else {
-				enc_edit = true;
-				sysSettings.newmode = sysSettings.omxMode;
-				dispMode();
+			if(activeOmxMode->shouldBlockEncEdit())
+			{
+				activeOmxMode->onEncoderButtonDown();
 			}
-			dirtyDisplay = true;
+			else{
+				encoderConfig.enc_edit = true;
+				sysSettings.newmode = sysSettings.omxMode;
+				omxDisp.dispMode();
+			}
 
+			omxDisp.setDirty();
 			break;
 		case Button::Up: //Serial.println("Button up");
-			if(sysSettings.omxMode == MODE_OM) {
-//				MM::sendControlChange(CC_OM1,0,sysSettings.midiChannel);
-			}
+			activeOmxMode->onEncoderButtonUp();
 			break;
 		case Button::UpLong: //Serial.println("Button uplong");
+			activeOmxMode->onEncoderButtonUpLong();
 			break;
 		default:
 			break;
@@ -1279,560 +618,48 @@ void loop() {
 	while(keypad.available()) {
 		auto e = keypad.next();
 		int thisKey = e.key();
-		int keyPos = thisKey - 11;
-		int seqKey = keyPos + (sequencer.patternPage[sequencer.playingPattern] * NUM_STEPKEYS);
+		// int keyPos = thisKey - 11;
+		// int seqKey = keyPos + (sequencer.patternPage[sequencer.playingPattern] * NUM_STEPKEYS);
 
 		if (e.down()){
-			screenSaverCounter = 0;
-			keyState[thisKey] = true;
+			omxScreensaver.resetCounter(); // screenSaverCounter = 0;
+			midiSettings.keyState[thisKey] = true;
 		}
 	
-		if (e.down() && thisKey == 0 && enc_edit) {
+		if (e.down() && thisKey == 0 && encoderConfig.enc_edit) {
 			// temp - save whenever the 0 key is pressed in encoder edit mode
 			saveToStorage();
 			//	Serial.println("EEPROM saved");
 		}
 
-		switch(sysSettings.omxMode) {
-			case MODE_OM: // Organelle
-				// Fall Through
+		activeOmxMode->onKeyUpdate(e);
 
-			case MODE_MIDI: // MIDI CONTROLLER
-
-				// ### KEY PRESS EVENTS
-				if (midiMacro){
-					if (e.clicks()==2 && thisKey == 0) {
-						m8AUX = !m8AUX;
-						if (!m8AUX) {
-							for(int m = 1; m < LED_COUNT; m++){
-								strip.setPixelColor(m, LEDOFF);
-							}
-						}
-					}
-					if (m8AUX) {
-						if (!e.held()){ 
-							if (e.down() && (thisKey > 10 && thisKey < 27 )){
-								// Mutes / Solos
-								m8mutesolo[keyPos] = !m8mutesolo[keyPos];
-								int mutePos = keyPos + 12;
-								if (m8mutesolo[keyPos]){
-									MM::sendNoteOn(mutePos, 1, midiMacroChan);
-								} else {
-									MM::sendNoteOff(mutePos, 0, midiMacroChan);
-								}							
-								break;
-							} else if (e.down() && (thisKey == 1)){
-								// release all mutes
-								for(int z = 0; z < 8; z++){
-									int mutePos = z + 12;
-									if(m8mutesolo[z]){
-										m8mutesolo[z] = false;
-										MM::sendNoteOff(mutePos, 0, midiMacroChan);
-									}
-								}								
-								break;
-							} else if (e.down() && (thisKey == 2)){
-								// ?
-								break;
-							} else if (e.down() && (thisKey == 3)){
-								// return to mixer
-								// hold shift 4 left 1 down, release shift
-								MM::sendNoteOn(1, 1, midiMacroChan); // Shift								
-								delay(40); 
-								MM::sendNoteOn(6, 1, midiMacroChan); // Up	
-								delay(20);							
-								MM::sendNoteOff(6, 0, midiMacroChan);
-								delay(40); 
-								MM::sendNoteOn(4, 1, midiMacroChan); // Left 
-								delay(20);
-								MM::sendNoteOff(4, 0, midiMacroChan);
-								delay(40);
-								MM::sendNoteOn(4, 1, midiMacroChan); // Left 
-								delay(20);
-								MM::sendNoteOff(4, 0, midiMacroChan);
-								delay(40);
-								MM::sendNoteOn(4, 1, midiMacroChan); // Left 
-								delay(20);
-								MM::sendNoteOff(4, 0, midiMacroChan);
-								delay(40);
-								MM::sendNoteOn(4, 1, midiMacroChan); // Left 
-								delay(20);
-								MM::sendNoteOff(4, 0, midiMacroChan);
-								delay(40);
-								MM::sendNoteOn(7, 1, midiMacroChan); // Down
-								delay(20);
-								MM::sendNoteOff(7, 0, midiMacroChan);		
-								MM::sendNoteOff(1, 0, midiMacroChan);
-								
-								break;
-							} else if (e.down() && (thisKey == 4)){
-								// snap save
-								MM::sendNoteOn(1, 1, midiMacroChan); // Shift	
-								delay(40);
-								MM::sendNoteOn(3, 1, midiMacroChan); // Option
-								delay(40);
-								MM::sendNoteOff(3, 0, midiMacroChan); 
-								MM::sendNoteOff(1, 0, midiMacroChan);
-								
-								break;
-							} else if (e.down() && (thisKey == 5)){
-								// snap load
-								MM::sendNoteOn(1, 1, midiMacroChan); // Shift								
-								delay(40); 
-								MM::sendNoteOn(2, 1, midiMacroChan); // Edit
-								delay(40); 
-								MM::sendNoteOff(2, 0, midiMacroChan);
-								MM::sendNoteOff(1, 0, midiMacroChan);								
-								
-								// then reset mutes/solos
-								for(int z = 0; z < 16; z++){
-									if(m8mutesolo[z]){
-										m8mutesolo[z] = false;
-									}
-								}
-
-								break;
-							} else if (e.down() && (thisKey == 6)){
-								// release all solos
-								for(int z = 8; z < 16; z++){
-									int mutePos = z + 12;
-									if(m8mutesolo[z]){
-										m8mutesolo[z] = false;
-										MM::sendNoteOff(mutePos, 0, midiMacroChan);
-									}
-								}
-								break;
-							} else if (e.down() && (thisKey == 7)){
-								// ??
-								break;
-							} else if (e.down() && (thisKey == 8)){
-								// ??
-								break;
-							} else if (e.down() && (thisKey == 9)){
-								// waveform
-								MM::sendNoteOn(6, 1, midiMacroChan); // Up
-								MM::sendNoteOn(7, 1, midiMacroChan); // Down
-								MM::sendNoteOn(5, 1, midiMacroChan); // Right
-								MM::sendNoteOn(4, 1, midiMacroChan); // Left
-								delay(40);
-
-								MM::sendNoteOff(6, 0, midiMacroChan); // Up
-								MM::sendNoteOff(7, 0, midiMacroChan); // Down
-								MM::sendNoteOff(5, 0, midiMacroChan); // Right
-								MM::sendNoteOff(4, 0, midiMacroChan); // Left
-
-								break;
-							} else if (e.down() && (thisKey == 10)){
-								// play
-								MM::sendNoteOn(0, 1, midiMacroChan); // Play
-								delay(40);
-								MM::sendNoteOff(0, 0, midiMacroChan); // Play
-
-//								MM::sendNoteOn(1, 1, midiMacroChan); // Shift
-//								MM::sendNoteOn(3, 1, midiMacroChan); // Option
-//								MM::sendNoteOn(2, 1, midiMacroChan); // Edit
-//								MM::sendNoteOn(6, 1, midiMacroChan); // Up
-//								MM::sendNoteOn(7, 1, midiMacroChan); // Down
-//								MM::sendNoteOn(4, 1, midiMacroChan); // Left
-//								MM::sendNoteOn(5, 1, midiMacroChan); // Right
-								break;
-							}
-						}	
-					}
-				}
-
-				// REGULAR KEY PRESSES
-				if (!e.held()){ 		// IGNORE LONG PRESS EVENTS
-					if (e.down() && thisKey != 0) {
-						//Serial.println(" pressed");
-						if (thisKey == 11 || thisKey == 12 || thisKey == 1 || thisKey == 2) {
-							if (midiAUX){
-								if (thisKey == 11 || thisKey == 12){
-									int amt = thisKey == 11 ? -1 : 1;
-									newoctave = constrain(octave + amt, -5, 4);
-									if (newoctave != octave){
-										octave = newoctave;
-									}
-								} else if (thisKey == 1 || thisKey == 2) {
-									int chng = thisKey == 1 ? -1 : 1;
-									miparam = constrain((miparam + chng ) % 15, 0, 14);
-									mmpage = miparam / NUM_DISP_PARAMS;
-								}
-							} else {
-								midiNoteOn(thisKey, defaultVelocity, sysSettings.midiChannel);
-							}
-						} else {
-							midiNoteOn(thisKey, defaultVelocity, sysSettings.midiChannel);
-						}
-					} else if(!e.down() && thisKey != 0) {
-						midiNoteOff(thisKey, sysSettings.midiChannel);
-					}
-				}
-//				Serial.println(e.clicks());
-
-				// AUX KEY
-				if (e.down() && thisKey == 0) {
-					// Hard coded Organelle stuff
-//					MM::sendControlChange(CC_AUX, 100, sysSettings.midiChannel);
-
-					if (!m8AUX){
-						midiAUX = true;
-					}
-					
-//					if (midiAUX) {
-//						// STOP CLOCK
-//						Serial.println("stop clock");
-//					} else {
-//						// START CLOCK
-//						Serial.println("start clock");
-//					}
-//					midiAUX = !midiAUX;
-
-
-				} else if (!e.down() && thisKey == 0) {
-					// Hard coded Organelle stuff
-//					MM::sendControlChange(CC_AUX, 0, sysSettings.midiChannel);
-					if (midiAUX) {
-						midiAUX = false;
-					}
-					// turn off leds
-					strip.setPixelColor(0, LEDOFF);
-					strip.setPixelColor(1, LEDOFF);
-					strip.setPixelColor(2, LEDOFF);
-					strip.setPixelColor(11, LEDOFF);
-					strip.setPixelColor(12, LEDOFF);
-				}
-				break;
-
-			case MODE_S1: // SEQUENCER 1
-				// fall through
-
-			case MODE_S2: // SEQUENCER 2
-				// Sequencer row keys
-
-				// ### KEY PRESS EVENTS
-
-				if (e.down() && thisKey != 0) {
-					// set key timer to zero
-//					keyPressTime[thisKey] = 0;
-
-					// NOTE SELECT
-					if (noteSelect){
-						if (noteSelection) {		// SET NOTE
-							// left and right keys change the octave
-							if (thisKey == 11 || thisKey == 26) {
-								int amt = thisKey == 11 ? -1 : 1;
-								newoctave = constrain(octave + amt, -5, 4);
-								if (newoctave != octave){
-									octave = newoctave;
-								}
-							// otherwise select the note
-							} else {
-								stepSelect = false;
-								selectedNote = thisKey;
-								int adjnote = notes[thisKey] + (octave * 12);
-								getSelectedStep()->note = adjnote;
-								if (!sequencer.playing){
-									seqNoteOn(thisKey, defaultVelocity, sequencer.playingPattern);
-								}
-							}
-							// see RELEASE events for more
-							dirtyDisplay = true;
-
-						} else if (thisKey == 1) {
-
-						} else if (thisKey == 2) {
-
-						} else if (thisKey > 2 && thisKey < 11) { // Pattern select keys
-							sequencer.playingPattern = thisKey - 3;
-							dirtyDisplay = true;
-
-						} else if ( thisKey > 10 ) {
-							selectedStep = seqKey; // was keyPos // set noteSelection to this step
-							stepSelect = true;
-							noteSelection = true;
-							dirtyDisplay = true;
-						}
-
-					// PATTERN PARAMS
-					} else if (patternParams) {
-						if (thisKey == 1) { // F1
-
-						} else if (thisKey == 2) {  // F2
-
-						} else if (thisKey > 2 && thisKey < 11) { // Pattern select keys
-
-							sequencer.playingPattern = thisKey - 3;
-
-							// COPY / PASTE / CLEAR
-							if (keyState[1] && !keyState[2]) {
-								copyPattern(sequencer.playingPattern);
-								displayMessagef("COPIED P-%d", sequencer.playingPattern + 1);
-							} else if (!keyState[1] && keyState[2]) {
-								pastePattern(sequencer.playingPattern);
-								displayMessagef("PASTED P-%d", sequencer.playingPattern + 1);
-							} else if (keyState[1] && keyState[2]) {
-								clearPattern(sequencer.playingPattern);
-								displayMessagef("CLEARED P-%d", sequencer.playingPattern + 1);
-							}
-
-							dirtyDisplay = true;
-						} else if ( thisKey > 10 ) {
-							// set pattern length with key
-							auto newPatternLen = thisKey - 10;
-							sequencer.setPatternLength(sequencer.playingPattern, newPatternLen );
-							if (sequencer.seqPos[sequencer.playingPattern] >= newPatternLen){
-								sequencer.seqPos[sequencer.playingPattern] = newPatternLen-1;
-								sequencer.patternPage[sequencer.playingPattern] = getPatternPage(sequencer.seqPos[sequencer.playingPattern]);
-							}
-							dirtyDisplay = true;
-						}
-
-					// STEP RECORD
-					} else if (stepRecord) {
-						selectedNote = thisKey;
-						selectedStep = sequencer.seqPos[sequencer.playingPattern];
-
-						int adjnote = notes[thisKey] + (octave * 12);
-						getSelectedStep()->note = adjnote;
-
-						if (!sequencer.playing){
-							seqNoteOn(thisKey, defaultVelocity, sequencer.playingPattern);
-						} // see RELEASE events for more
-						stepDirty = true;
-						dirtyDisplay = true;
-
-					// MIDI SOLO
-					} else if (sequencer.getCurrentPattern()->solo) {
-						midiNoteOn(thisKey, defaultVelocity, sequencer.getCurrentPattern()->channel+1);
-
-					// REGULAR SEQ MODE
-					} else {
-						if (keyState[1] && keyState[2]) {
-							seqPages = true;
-						}
-						if (thisKey == 1) {
-//							seqResetFlag = true;					// RESET ALL SEQUENCES TO FIRST/LAST STEP
-																	// MOVED DOWN TO AUX KEY
-
-						} else if (thisKey == 2) { 					// CHANGE PATTERN DIRECTION
-//							sequencer.getCurrentPattern()->reverse = !sequencer.getCurrentPattern()->reverse;
-
-						// BLACK KEYS - PATTERNS
-						} else if (thisKey > 2 && thisKey < 11) { // Pattern select
-
-							// CHECK keyState[] FOR LONG PRESS THINGS
-
-							// If ONLY KEY 1 is down + pattern is not playing = STEP RECORD
-							if (keyState[1] && !keyState[2] && !sequencer.playing) {
-								sequencer.playingPattern = thisKey-3;
-								sequencer.seqPos[sequencer.playingPattern] = 0;
-								sequencer.patternPage[sequencer.playingPattern] = 0;	// Step Record always starts from first page
-								stepRecord = true;
-								displayMessagef("STEP RECORD");
-//								dirtyDisplay = true;
-
-							// If KEY 2 is down + pattern = PATTERN MUTE
-							} else if (keyState[2]) {
-								if (sequencer.getPattern(thisKey - 3)->mute){
-									displayMessagef("UNMUTE P-%d", (thisKey - 3)+1);
-								}else {
-									displayMessagef("MUTE P-%d", (thisKey - 3)+1);
-								}
-								sequencer.getPattern(thisKey - 3)->mute = !sequencer.getPattern(thisKey-3)->mute;
-							} else {
-								sequencer.playingPattern = thisKey - 3;
-							}
-							dirtyDisplay = true;
-
-						// SEQUENCE 1-16 STEP KEYS
-						} else if (thisKey > 10) {
-
-							if (keyState[1] && keyState[2]) {		// F1+F2 HOLD
-								if (!stepRecord){ // IGNORE LONG PRESSES IN STEP RECORD
-									if (keyPos <= getPatternPage(sequencer.getCurrentPattern()->len) ){
-										sequencer.patternPage[sequencer.playingPattern] = keyPos;
-									}
-									displayMessagef("PATT PAGE %d", keyPos + 1);
-								}
-							} else if (keyState[1]) {		// F1 HOLD
-									if (!stepRecord && !patternParams){ 		// IGNORE LONG PRESSES IN STEP RECORD and Pattern Params
-										selectedStep = thisKey - 11; // set noteSelection to this step
-										noteSelect = true;
-										stepSelect = true;
-										noteSelection = true;
-										dirtyDisplay = true;
-										displayMessagef("NOTE SELECT");
-										// re-toggle the key you just held
-//										if (getSelectedStep()->trig == TRIGTYPE_PLAY || getSelectedStep()->trig == TRIGTYPE_MUTE ) {
-//											getSelectedStep()->trig = (getSelectedStep()->trig == TRIGTYPE_PLAY ) ? TRIGTYPE_MUTE : TRIGTYPE_PLAY;
-//										}
-									}
-
-							} else if (keyState[2]) {		// F2 HOLD
-
-							} else {
-								// TOGGLE STEP ON/OFF
-								if (sequencer.getCurrentPattern()->steps[seqKey].trig == TRIGTYPE_PLAY || sequencer.getCurrentPattern()->steps[seqKey].trig == TRIGTYPE_MUTE ) {
-									sequencer.getCurrentPattern()->steps[seqKey].trig = (sequencer.getCurrentPattern()->steps[seqKey].trig == TRIGTYPE_PLAY ) ? TRIGTYPE_MUTE : TRIGTYPE_PLAY;
-								}
-							}
-						}
-					}
-				}
-
-				// ### KEY RELEASE EVENTS
-
-				if (!e.down() && thisKey != 0) {
-					// MIDI SOLO
-					if (sequencer.getCurrentPattern()->solo) {
-						midiNoteOff(thisKey, sequencer.getCurrentPattern()->channel+1);
-					}
-				}
-
-				if (!e.down() && thisKey != 0 && (noteSelection || stepRecord) && selectedNote > 0) {
-					if (!sequencer.playing){
-						seqNoteOff(thisKey, sequencer.playingPattern);
-					}
-					if (stepRecord && stepDirty) {
-						step_ahead();
-						stepDirty = false;
-						// EXIT STEP RECORD AFTER THE LAST STEP IN PATTERN
-						if (sequencer.seqPos[sequencer.playingPattern] == 0){
-							stepRecord = false;
-						}
-					}
-				}
-
-				// AUX KEY PRESS EVENTS
-
-				if (e.down() && thisKey == 0) {
-
-					if (noteSelect){
-						if (noteSelection){
-							selectedStep = 0;
-							selectedNote = 0;
-						} else {
-
-						}
-						noteSelection = false;
-						noteSelect = !noteSelect;
-						dirtyDisplay = true;
-
-					} else if (patternParams){
-						patternParams = !patternParams;
-						dirtyDisplay = true;
-
-					} else if (stepRecord){
-						stepRecord = !stepRecord;
-						dirtyDisplay = true;
-					} else if (seqPages){
-						seqPages = false;
-					} else {
-						if (keyState[1] || keyState[2]) { 				// CHECK keyState[] FOR LONG PRESS OF FUNC KEYS
-							if (keyState[1]) {
-								sequencer.seqResetFlag = true;		// RESET ALL SEQUENCES TO FIRST/LAST STEP
-								displayMessagef("RESET");
-
-							} else if (keyState[2]) { 					// CHANGE PATTERN DIRECTION
-								sequencer.getCurrentPattern()->reverse = !sequencer.getCurrentPattern()->reverse;
-								if (sequencer.getCurrentPattern()->reverse) {
-									displayMessagef("<< REV");
-								} else{
-									displayMessagef("FWD >>");
-								}
-							}
-							dirtyDisplay = true;
-						} else {
-							if (sequencer.playing){
-								// stop transport
-								sequencer.playing = 0;
-								allNotesOff();
-	//							Serial.println("stop transport");
-								seqStop();
-							} else {
-								// start transport
-	//							Serial.println("start transport");
-								seqStart();
-							}
-						}
-					}
-
-				// AUX KEY RELEASE EVENTS
-
-				} else if (!e.down() && thisKey == 0) {
-
-				}
-				
-//				strip.show();
-				break;
-
-			default:
-				break;
-		}
 		// END MODE SWITCH
 
 		if (!e.down()){
-			keyState[thisKey] = false;
-		}
-		if (!keyState[1] && !keyState[2]) {
-			seqPages = false;
+			midiSettings.keyState[thisKey] = false;
 		}
 
+		// TODO I believe this is handled in omx_mode_sequencer.onKeyUpdate()
+		// need to test and make sure this works
+		// if (!midiSettings.keyState[1] && !midiSettings.keyState[2]) {
+		// 	seqPages = false;
+		// }
 		
 		// ### LONG KEY SWITCH PRESS
 		if (e.held()) {
 			// DO LONG PRESS THINGS
-			switch (sysSettings.omxMode){
-				case MODE_MIDI:
-					break;
-				case MODE_S1:
-					// fall through
-				case MODE_S2:
-					if (!sequencer.getCurrentPattern()->solo){
-						// TODO: access key state directly in omx_keypad.h
-						if (keyState[1] && keyState[2]) {
-							seqPages = true;
-						} else if (!keyState[1] && !keyState[2]) { // SKIP LONG PRESS IF FUNC KEYS ARE ALREDY HELD
-							if (thisKey > 2 && thisKey < 11){ // skip AUX key, get pattern keys
-								patternParams = true;
-								dirtyDisplay = true;
-								displayMessagef("PATT PARAMS");
-							} else if (thisKey > 10){
-								if (!stepRecord && !patternParams){ 		// IGNORE LONG PRESSES IN STEP RECORD and Pattern Params
-									selectedStep = (thisKey - 11) + (sequencer.patternPage[sequencer.playingPattern] * NUM_STEPKEYS); // set noteSelection to this step
-									noteSelect = true;
-									stepSelect = true;
-									noteSelection = true;
-									dirtyDisplay = true;
-									displayMessagef("NOTE SELECT");
-									// re-toggle the key you just held
-//									if ( getSelectedStep()->trig == TRIGTYPE_PLAY || getSelectedStep()->trig == TRIGTYPE_MUTE ) {
-//										getSelectedStep()->trig = ( getSelectedStep()->trig == TRIGTYPE_PLAY ) ? TRIGTYPE_MUTE : TRIGTYPE_PLAY;
-//									}
-								}
-							}
-						}
-					}
-					break;
-				default:
-					break;
-			} // END MODE SWITCH
+			activeOmxMode->onKeyHeldUpdate(e); // Only the sequencer uses this, could probably be handled in onKeyUpdate() but keyStates are modified before this stuff happens. 
 		} // END IF HELD
 
 	}  // END KEYS WHILE
 
-	if (!screenSaverMode){
+	if (!sysSettings.screenSaverMode){
 
 		// ############### MODES DISPLAY  ##############
 		//
-		if(messageTextTimer > 0) {
-			messageTextTimer -= passed;
-			if(messageTextTimer <= 0) {
-				dirtyDisplay = true;
-				messageTextTimer = 0;
-			}
-		}
+
+		omxDisp.UpdateMessageTextTimer();
 	
 		switch(sysSettings.omxMode){
 			case MODE_OM: 						// ############## ORGANELLE MODE
@@ -1841,7 +668,7 @@ void loop() {
 				//playingPattern = 0; 		// DEFAULT MIDI MODE TO THE FIRST PATTERN SLOT
 				midi_leds();				// SHOW LEDS
 				if (dirtyDisplay){			// DISPLAY
-					if (!enc_edit){
+					if (!encoderConfig.enc_edit){
 						int pselected = miparam % NUM_DISP_PARAMS;
 						if (mmpage == 0){
 							dispGenericMode(SUBMODE_MIDI, pselected);
@@ -1861,7 +688,7 @@ void loop() {
 					midi_leds();
 				}
 				if (dirtyDisplay){			// DISPLAY
-					if (!enc_edit && messageTextTimer == 0){	// show only if not encoder edit or dialog display
+					if (!encoderConfig.enc_edit && messageTextTimer == 0){	// show only if not encoder edit or dialog display
 						if (!noteSelect and !patternParams and !stepRecord){
 							int pselected = sqparam % NUM_DISP_PARAMS;
 							if (sqpage == 0){
@@ -1911,31 +738,24 @@ void loop() {
 			case MODE_OM: 						// ############## ORGANELLE MODE
 				// FALL THROUGH
 			case MODE_MIDI:							// ############## MIDI KEYBOARD
-					sleepModeOne();
+					// sleepModeOne();
+					omxScreensaver.updateLEDs();
 				break;
 			default:
 				break;
 		}
 		// clear display
 		display.clearDisplay();
-		dirtyDisplay = true;
+		omxDisp.setDirty();
 	}
 
 	// DISPLAY at end of loop
 
-	if (dirtyDisplay) {
-		if (dirtyDisplayTimer > displayRefreshRate) {
-			display.display();
-			dirtyDisplay = false;
-			dirtyDisplayTimer = 0;
-		}
-	}
+	omxDisp.showDisplay();
 
-	// are pixels dirty
-	if (dirtyPixels) {
-		strip.show();
-		dirtyPixels = false;
-	}
+	
+
+	omxLeds.showLeds();
 
 	while (MM::usbMidiRead()) {
 		// incoming messages - see handlers
@@ -1990,7 +810,7 @@ void OnNoteOn(byte channel, byte note, byte velocity) {
 		strip.setPixelColor(midiKeyMap[thisKey], keyColor);         //  Set pixel's color (in RAM)
 	//	dirtyPixels = true;
 		strip.show();
-		dirtyDisplay = true;
+		omxDisp.setDirty();
 	}
 }
 void OnNoteOff(byte channel, byte note, byte velocity) {
@@ -2008,7 +828,7 @@ void OnNoteOff(byte channel, byte note, byte velocity) {
 		strip.setPixelColor(midiKeyMap[thisKey], LEDOFF);         //  Set pixel's color (in RAM)
 	//	dirtyPixels = true;
 		strip.show();
-		dirtyDisplay = true;
+		omxDisp.setDirty();
 	}
 	if (midiSoftThru) {
 		MM::sendNoteOffHW(note, velocity, channel);
@@ -2098,107 +918,10 @@ void rainbow(int wait) {
 		delay(wait);  // Pause for a moment
 	}
 }
-void setAllLEDS(int R, int G, int B) {
-	for(int i=0; i<LED_COUNT; i++) { // For each pixel...
-		strip.setPixelColor(i, strip.Color(R, G, B));
-	}
-	dirtyPixels = true;
-}
 
-// #### COLOR FUNCTIONS
-// Input a value 0 to 255 to get a color value.
-// The colours are a transition r - g - b - back to r.
-uint32_t Wheel(byte WheelPos) {
-	WheelPos = 255 - WheelPos;
-	if(WheelPos < 85) {
-		return strip.Color(255 - WheelPos * 3, 0, WheelPos * 3);
-	}
-	if(WheelPos < 170) {
-		WheelPos -= 85;
-		return strip.Color(0, WheelPos * 3, 255 - WheelPos * 3);
-	}
-	WheelPos -= 170;
-	return strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
-}
-void colorWipe(byte red, byte green, byte blue, int SpeedDelay) {
-  for(uint16_t i=0; i<strip.numPixels(); i++) {
-      strip.setPixelColor(i, strip.Color(red, green, blue));
-      strip.show();
-      delay(SpeedDelay);
-  }
-}
-void theaterChaseRainbow(uint8_t wait) {		//Theatre-style crawling lights with rainbow effect
-	for (int j=0; j < 256; j++) {     // cycle all 256 colors in the wheel
-		for (int q=0; q < 3; q++) {
-			for (uint16_t i=0; i < strip.numPixels(); i=i+3) {
-				strip.setPixelColor(i+q, Wheel( (i+j) % 255));    //turn every third pixel on
-			}
-			strip.show();
-			delay(wait);
-			for (uint16_t i=0; i < strip.numPixels(); i=i+3) {
-				strip.setPixelColor(i+q, 0);        //turn every third pixel off
-			}
-		}
-	}
-}
-void CylonBounce(byte red, byte green, byte blue, int EyeSize, int SpeedDelay, int ReturnDelay, int start, int end){
-  for(int i = start; i < end-EyeSize-2; i++) {
-    setAllLEDS(0,0,0);
-    strip.setPixelColor(i, strip.Color(red/10, green/10, blue/10));
-    for(int j = 1; j <= EyeSize; j++) {
-      strip.setPixelColor(i+j, strip.Color(red, green, blue));
-    }
-    strip.setPixelColor(i+EyeSize+1, strip.Color(red/10, green/10, blue/10));
-    strip.show();
-    delay(SpeedDelay);
-  }
-  delay(ReturnDelay);
-  for(int i = end-EyeSize-2; i > start; i--) {
-    setAllLEDS(0,0,0);
-    strip.setPixelColor(i, strip.Color(red/10, green/10, blue/10));
-    for(int j = 1; j <= EyeSize; j++) {
-      strip.setPixelColor(i+j, strip.Color(red, green, blue));
-    }
-    strip.setPixelColor(i+EyeSize+1, strip.Color(red/10, green/10, blue/10));
-    strip.show();
-    delay(SpeedDelay);
-  }
-  delay(ReturnDelay);
-}
-void RolandFill(byte red, byte green, byte blue, int start, int end, int SpeedDelay){
-	for(uint16_t j=end; j>start; j--) {
-		for(uint16_t i=start; i<end; i++) {
-			strip.setPixelColor(i, strip.Color(red, green, blue));
-			strip.show();
-			if (i < j){
-				strip.setPixelColor(i, 0);
 
-			}
-			if (!screenSaverMode){
-				return;
-			}
-		}
-		strip.setPixelColor(j, strip.Color(red, green, blue));
-		strip.show();
-	}
-	for(uint16_t j=end; j>start-1; j--) {
-		for(uint16_t i=start; i<end+1; i++) {
-			strip.setPixelColor(i, strip.Color(red, green, blue));
-			strip.show();
-			if (i > j){
-				strip.setPixelColor(i, 0);
 
-			}
-			if (!screenSaverMode){
-				return;
-			}
-		}
-		if (j != start){
-			strip.setPixelColor(j, strip.Color(red, green, blue));
-		}
-		strip.show();
-	}
-}
+
 
 // #### OLED STUFF
 

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -169,7 +169,7 @@ void setup()
 
 void show_current_step(int patternNum)
 {
-	omxLeds.updateLeds();
+	if(sysSettings.screenSaverMode && !sequencer.playing) return; // Screensaver active and not playing, don't update sequencer LEDs. 
 
 	omxModeSeq.showCurrentStep(patternNum);
 }
@@ -527,6 +527,8 @@ void saveHeader()
 			storage->write(EEPROM_HEADER_ADDRESS + 4 + i + (5 * b), pots[b][i]);
 		}
 	}
+
+	// 29 bytes
 }
 
 // returns true if the header contained initialized data

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -701,7 +701,7 @@ void loadPatterns(void)
 // currently saves everything ( mode + patterns )
 void saveToStorage(void)
 {
-	//	Serial.println( "saving..." );
+	// Serial.println( "saving..." );
 	saveHeader();
 	savePatterns();
 }
@@ -712,7 +712,7 @@ bool loadFromStorage(void)
 	// This load can happen soon after Serial.begin - enable this 'wait for Serial' if you need to Serial.print during loading
 	// while( !Serial );
 
-	//	Serial.println( "read the header" );
+	// Serial.println( "read the header" );
 	bool bContainedData = loadHeader();
 
 	if (bContainedData)
@@ -721,6 +721,8 @@ bool loadFromStorage(void)
 		loadPatterns();
 		return true;
 	}
+
+	// Serial.println( "failed to load" );
 
 	return false;
 }

--- a/OMX-27-firmware/config.cpp
+++ b/OMX-27-firmware/config.cpp
@@ -81,8 +81,11 @@ bool m8mutesolo[] = {false, false, false, false, false, false, false, false, fal
 SysSettings sysSettings;
 PotSettings potSettings;
 MidiConfig midiSettings;
+MidiPage midiPageParams;
 MidiMacroConfig midiMacroConfig;
 EncoderConfig encoderConfig;
 ClockConfig clockConfig;
+SequencerConfig seqConfig;
+SequencerPage seqPageParams;
 ColorConfig colorConfig;
 

--- a/OMX-27-firmware/config.cpp
+++ b/OMX-27-firmware/config.cpp
@@ -30,6 +30,8 @@ const int LED_COUNT = 27;
 	const int analogPins[] = {A10,22,21,20,16}; // on 1.0
 #endif
 
+const int potCount = NUM_CC_POTS;
+
 int pots[NUM_CC_BANKS][NUM_CC_POTS] = {
 	{CC1,CC2,CC3,CC4,CC5},
 	{29,30,31,32,33},
@@ -73,3 +75,14 @@ const int steps[] = {0,
 11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26};
 
 const int midiKeyMap[] = {12,1,13,2,14,15,3,16,4,17,5,18,19,6,20,7,21,22,8,23,9,24,10,25,26};
+
+bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
+
+SysSettings sysSettings;
+PotSettings potSettings;
+MidiConfig midiSettings;
+MidiMacroConfig midiMacroConfig;
+EncoderConfig encoderConfig;
+ClockConfig clockConfig;
+ColorConfig colorConfig;
+

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -11,12 +11,12 @@
 
 // #include <cstdarg>
 
-//const int OMX_VERSION = 1.6.0;
+//const int OMX_VERSION = 1.7.0beta
 
 /* * firmware metadata  */
-// OMX_VERSION = 1.6.0
+// OMX_VERSION = 1.7.0beta
 const int MAJOR_VERSION = 1;
-const int MINOR_VERSION = 6;
+const int MINOR_VERSION = 7;
 const int POINT_VERSION = 0;
 
 const int DEVICE_ID     = 2;

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -67,6 +67,8 @@ extern const int analogPins[];
 #define NUM_CC_POTS 5
 extern int pots[NUM_CC_BANKS][NUM_CC_POTS];         // the MIDI CC (continuous controller) for each analog input
 
+using Micros = unsigned long;    // for tracking time per pattern
+
 struct SysSettings {
 	OMXMode omxMode = DEFAULT_MODE;
 	OMXMode newmode = DEFAULT_MODE;
@@ -92,8 +94,7 @@ struct PotSettings
 	int potCC = pots[potbank][0];
 	int potVal = analogValues[0];
 	int potNum = 0;
-	bool plockDirty[NUM_CC_POTS] = {false, false, false, false, false};
-	int prevPlock[NUM_CC_POTS] = {0, 0, 0, 0, 0};
+	
 };
 // Put in global struct to share across classes
 extern PotSettings potSettings;
@@ -128,6 +129,12 @@ struct MidiConfig
 
 extern MidiConfig midiSettings;
 
+struct MidiPage {
+	int miparam = 0; // midi params item counter
+    int mmpage = 0;
+};
+extern MidiPage midiPageParams;
+
 struct MidiMacroConfig {
 	int midiMacro = 0;
 	bool m8AUX = false;
@@ -150,9 +157,47 @@ struct ClockConfig {
 	unsigned long tempoStartTime;
 	unsigned long tempoEndTime;
 	float step_delay;
+
+	volatile unsigned long step_micros;
+	volatile unsigned long ppqInterval;
 };
 
 extern ClockConfig clockConfig;
+
+struct SequencerConfig {
+	int selectedStep = 0;
+	bool plockDirty[NUM_CC_POTS] = {false, false, false, false, false};
+	int prevPlock[NUM_CC_POTS] = {0, 0, 0, 0, 0};
+
+	volatile unsigned long noteon_micros;
+	volatile unsigned long noteoff_micros;
+
+    bool noteSelect = false;
+    bool noteSelection = false;
+
+    int selectedNote = 0;
+    // int omxSeqSelectedStep = 0;
+    bool stepSelect = false;
+    bool stepRecord = false;
+    bool stepDirty = false;
+};
+extern SequencerConfig seqConfig;
+
+struct SequencerPage {
+	bool patternParams = false;
+    bool seqPages = false;
+
+	int nspage = 0;
+    int pppage = 0;
+    int sqpage = 0;
+    int srpage = 0;
+
+    int nsparam = 0; // note select params
+    int ppparam = 0; // pattern params
+    int sqparam = 0; // seq params
+    int srparam = 0; // step record params
+};
+extern SequencerPage seqPageParams;
 
 struct ColorConfig
 {

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <ResponsiveAnalogRead.h>
+
 // #include <cstdarg>
 
 //const int OMX_VERSION = 1.6.0;
@@ -68,21 +70,27 @@ struct SysSettings {
 	uint8_t midiChannel = 0;
 	int playingPattern;
 	bool refresh = false;
+	bool screenSaverMode = false;
+	Micros timeElasped;
 };
 
 SysSettings sysSettings;
 
+const int potCount = NUM_CC_POTS;
+
 struct PotSettings
 {
+	ResponsiveAnalogRead *analog[NUM_CC_POTS];
+
 	// ANALOGS
 	int potbank = 0;
-	int analogValues[5] = {0, 0, 0, 0, 0}; // default values
-	int potValues[5] = {0, 0, 0, 0, 0};
+	int analogValues[NUM_CC_POTS] = {0, 0, 0, 0, 0}; // default values
+	int potValues[NUM_CC_POTS] = {0, 0, 0, 0, 0};
 	int potCC = pots[potbank][0];
 	int potVal = analogValues[0];
 	int potNum = 0;
-	bool plockDirty[5] = {false, false, false, false, false};
-	int prevPlock[5] = {0, 0, 0, 0, 0};
+	bool plockDirty[NUM_CC_POTS] = {false, false, false, false, false};
+	int prevPlock[NUM_CC_POTS] = {0, 0, 0, 0, 0};
 };
 // Put in global struct to share across classes
 PotSettings potSettings;
@@ -116,6 +124,7 @@ struct MidiConfig
 MidiConfig midiSettings;
 
 struct MidiMacroConfig {
+	bool midiAUX = false;
 	int midiMacro = 0;
 	bool m8AUX = false;
 	int midiMacroChan = 10;
@@ -123,6 +132,33 @@ struct MidiMacroConfig {
 
 MidiMacroConfig midiMacroConfig;
 
+struct EncoderConfig {
+	bool enc_edit = false;
+};
+
+EncoderConfig encoderConfig;
+
+struct ClockConfig {
+	float clockbpm = 120;
+	float newtempo = clockbpm;
+	unsigned long tempoStartTime;
+	unsigned long tempoEndTime;
+	float step_delay;
+};
+
+ClockConfig clockConfig;
+
+struct ColorConfig
+{
+	uint32_t screensaverColor = 0xFF0000;
+	uint32_t stepColor = 0x000000;
+	uint32_t muteColor = 0x000000;
+	uint16_t midiBg_Hue = 0;
+	uint8_t midiBg_Sat = 255;
+	uint8_t midiBg_Brightness = 255;
+};
+
+ColorConfig colorConfig;
 
 #define NUM_DISP_PARAMS 5
 

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -120,18 +120,20 @@ struct MidiConfig
     bool midiInToCV = true;
     bool midiSoftThru = false;
 	int pitchCV;
+	bool midiAUX = false;
 };
 
 MidiConfig midiSettings;
 
 struct MidiMacroConfig {
-	bool midiAUX = false;
 	int midiMacro = 0;
 	bool m8AUX = false;
 	int midiMacroChan = 10;
 };
 
 MidiMacroConfig midiMacroConfig;
+
+bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
 
 struct EncoderConfig {
 	bool enc_edit = false;

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -70,6 +70,60 @@ struct SysSettings {
 	bool refresh = false;
 };
 
+SysSettings sysSettings;
+
+struct PotSettings
+{
+	// ANALOGS
+	int potbank = 0;
+	int analogValues[5] = {0, 0, 0, 0, 0}; // default values
+	int potValues[5] = {0, 0, 0, 0, 0};
+	int potCC = pots[potbank][0];
+	int potVal = analogValues[0];
+	int potNum = 0;
+	bool plockDirty[5] = {false, false, false, false, false};
+	int prevPlock[5] = {0, 0, 0, 0, 0};
+};
+// Put in global struct to share across classes
+PotSettings potSettings;
+
+struct MidiConfig
+{
+    int defaultVelocity = 100;
+    int octave = 0; // default C4 is 0 - range is -4 to +5
+    int newoctave = octave;
+    int transpose = 0;
+    int rotationAmt = 0;
+
+    uint8_t swing = 0;
+    const int maxswing = 100;
+    // int swing_values[maxswing] = {0, 1, 3, 5, 52, 66, 70, 72, 80, 99 }; // 0 = off, <50 early swing , >50 late swing, 99=drunken swing
+
+    bool keyState[27] = {false};
+    int midiKeyState[27] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+    int midiChannelState[27] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+    int rrChannel = 0;
+    bool midiRoundRobin = false;
+    int midiRRChannelOffset = 0;
+    int midiRRChannelCount = 1;
+    uint8_t midiLastNote = 0;
+    int currpgm = 0;
+    int currbank = 0;
+    bool midiInToCV = true;
+    bool midiSoftThru = false;
+};
+
+MidiConfig midiSettings;
+
+struct MidiMacroConfig {
+	int midiMacro = 0;
+	bool m8AUX = false;
+	int midiMacroChan = 10;
+};
+
+MidiMacroConfig midiMacroConfig;
+
+
 #define NUM_DISP_PARAMS 5
 
 extern const int gridh;

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifndef OMX_CONFIG_DONE
+#define OMX_CONFIG_DONE // prevent redifinition pragma once should handle though. 
+
 #include <Arduino.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -71,12 +74,12 @@ struct SysSettings {
 	int playingPattern;
 	bool refresh = false;
 	bool screenSaverMode = false;
-	Micros timeElasped;
+	unsigned long timeElasped;
 };
 
-SysSettings sysSettings;
+extern SysSettings sysSettings;
 
-const int potCount = NUM_CC_POTS;
+extern const int potCount;
 
 struct PotSettings
 {
@@ -93,7 +96,7 @@ struct PotSettings
 	int prevPlock[NUM_CC_POTS] = {0, 0, 0, 0, 0};
 };
 // Put in global struct to share across classes
-PotSettings potSettings;
+extern PotSettings potSettings;
 
 struct MidiConfig
 {
@@ -123,7 +126,7 @@ struct MidiConfig
 	bool midiAUX = false;
 };
 
-MidiConfig midiSettings;
+extern MidiConfig midiSettings;
 
 struct MidiMacroConfig {
 	int midiMacro = 0;
@@ -131,15 +134,15 @@ struct MidiMacroConfig {
 	int midiMacroChan = 10;
 };
 
-MidiMacroConfig midiMacroConfig;
+extern MidiMacroConfig midiMacroConfig;
 
-bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};
+extern bool m8mutesolo[];
 
 struct EncoderConfig {
 	bool enc_edit = false;
 };
 
-EncoderConfig encoderConfig;
+extern EncoderConfig encoderConfig;
 
 struct ClockConfig {
 	float clockbpm = 120;
@@ -149,7 +152,7 @@ struct ClockConfig {
 	float step_delay;
 };
 
-ClockConfig clockConfig;
+extern ClockConfig clockConfig;
 
 struct ColorConfig
 {
@@ -161,7 +164,7 @@ struct ColorConfig
 	uint8_t midiBg_Brightness = 255;
 };
 
-ColorConfig colorConfig;
+extern ColorConfig colorConfig;
 
 #define NUM_DISP_PARAMS 5
 
@@ -241,3 +244,5 @@ extern byte colPins[COLS]; // column pins for key switches
 extern const int notes[];
 extern const int steps[];
 extern const int midiKeyMap[];
+
+#endif

--- a/OMX-27-firmware/config.h
+++ b/OMX-27-firmware/config.h
@@ -119,6 +119,7 @@ struct MidiConfig
     int currbank = 0;
     bool midiInToCV = true;
     bool midiSoftThru = false;
+	int pitchCV;
 };
 
 MidiConfig midiSettings;

--- a/OMX-27-firmware/omx_disp.cpp
+++ b/OMX-27-firmware/omx_disp.cpp
@@ -58,6 +58,10 @@ void OmxDisp::displayMessagef(const char *fmt, ...)
     displayMessage(buf);
 }
 
+bool OmxDisp::isMessageActive(){
+    return messageTextTimer > 0;
+}
+
 void OmxDisp::u8g2centerText(const char *s, int16_t x, int16_t y, uint16_t w, uint16_t h)
 {
     //  int16_t bx, by;

--- a/OMX-27-firmware/omx_disp.cpp
+++ b/OMX-27-firmware/omx_disp.cpp
@@ -21,7 +21,7 @@ void OmxDisp::clearDisplay()
 {
     // Clear display
     display.display();
-    dirtyDisplay = true;
+    setDirty();
 }
 
 void OmxDisp::drawStartupScreen()

--- a/OMX-27-firmware/omx_disp.cpp
+++ b/OMX-27-firmware/omx_disp.cpp
@@ -348,7 +348,7 @@ void OmxDisp::clearLegends()
     legendText[3] = "";
 }
 
-void OmxDisp::dispGenericMode(int submode, int selected)
+void OmxDisp::dispGenericMode(int selected)
 {
     // const char* legends[4] = {"","","",""};
     // int legendVals[4] = {0,0,0,0};

--- a/OMX-27-firmware/omx_disp.cpp
+++ b/OMX-27-firmware/omx_disp.cpp
@@ -3,7 +3,6 @@
 #include "omx_disp.h"
 #include "consts.h"
 #include "ClearUI.h"
-#include "omx_midi_settings.h"
 
 U8G2_FOR_ADAFRUIT_GFX u8g2_display;
 
@@ -12,29 +11,32 @@ OmxDisp::OmxDisp()
 {
 }
 
-void OmxDisp::setup() {
+void OmxDisp::setup()
+{
     initializeDisplay();
-	u8g2_display.begin(display);
+    u8g2_display.begin(display);
 }
 
-void OmxDisp::clearDisplay(){
+void OmxDisp::clearDisplay()
+{
     // Clear display
-	display.display();
-	dirtyDisplay = true;
+    display.display();
+    dirtyDisplay = true;
 }
 
-
-void OmxDisp::drawStartupScreen(){
+void OmxDisp::drawStartupScreen()
+{
     display.clearDisplay();
-	testdrawrect();
-	delay(200);
-	display.clearDisplay();
-	u8g2_display.setForegroundColor(WHITE);
-	u8g2_display.setBackgroundColor(BLACK);
-	drawLoading();
+    testdrawrect();
+    delay(200);
+    display.clearDisplay();
+    u8g2_display.setForegroundColor(WHITE);
+    u8g2_display.setBackgroundColor(BLACK);
+    drawLoading();
 }
 
-void OmxDisp::displayMessage(const char* msg) {
+void OmxDisp::displayMessage(const char *msg)
+{
     display.fillRect(0, 0, 128, 32, BLACK);
     u8g2_display.setFontMode(1);
     u8g2_display.setFont(FONT_TENFAT);
@@ -46,7 +48,8 @@ void OmxDisp::displayMessage(const char* msg) {
     dirtyDisplay = true;
 }
 
-void OmxDisp::displayMessagef(const char* fmt, ...) {
+void OmxDisp::displayMessagef(const char *fmt, ...)
+{
     va_list args;
     va_start(args, fmt);
     char buf[24];
@@ -55,262 +58,277 @@ void OmxDisp::displayMessagef(const char* fmt, ...) {
     displayMessage(buf);
 }
 
-void OmxDisp::u8g2centerText(const char* s, int16_t x, int16_t y, uint16_t w, uint16_t h) {
-//  int16_t bx, by;
-	uint16_t bw, bh;
-	bw = u8g2_display.getUTF8Width(s);
-	bh = u8g2_display.getFontAscent();
-	u8g2_display.setCursor(
-		x + (w - bw) / 2,
-		y + (h - bh) / 2
-	);
-	u8g2_display.print(s);
+void OmxDisp::u8g2centerText(const char *s, int16_t x, int16_t y, uint16_t w, uint16_t h)
+{
+    //  int16_t bx, by;
+    uint16_t bw, bh;
+    bw = u8g2_display.getUTF8Width(s);
+    bh = u8g2_display.getFontAscent();
+    u8g2_display.setCursor(
+        x + (w - bw) / 2,
+        y + (h - bh) / 2);
+    u8g2_display.print(s);
 }
 
 void OmxDisp::u8g2centerNumber(int n, uint16_t x, uint16_t y, uint16_t w, uint16_t h)
 {
-	char buf[8];
-	itoa(n, buf, 10);
-	u8g2centerText(buf, x, y, w, h);
+    char buf[8];
+    itoa(n, buf, 10);
+    u8g2centerText(buf, x, y, w, h);
 }
 
-void OmxDisp::testdrawrect() {
-	display.clearDisplay();
+void OmxDisp::testdrawrect()
+{
+    display.clearDisplay();
 
-	for(int16_t i=0; i<display.height()/2; i+=2) {
-		display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
-		display.display(); // Update screen with each newly-drawn rectangle
-		delay(1);
-	}
+    for (int16_t i = 0; i < display.height() / 2; i += 2)
+    {
+        display.drawRect(i, i, display.width() - 2 * i, display.height() - 2 * i, SSD1306_WHITE);
+        display.display(); // Update screen with each newly-drawn rectangle
+        delay(1);
+    }
 
-	delay(500);
+    delay(500);
 }
 
-void OmxDisp::drawLoading() {
-	const char* loader[] = {"\u25f0", "\u25f1", "\u25f2", "\u25f3"};
-	display.clearDisplay();
-	u8g2_display.setFontMode(0);
-	for(int16_t i=0; i<16; i+=1) {
-		display.clearDisplay();
-		u8g2_display.setCursor(18,18);
-		u8g2_display.setFont(FONT_TENFAT);
-		u8g2_display.print("OMX-27");
-		u8g2_display.setFont(FONT_SYMB_BIG);
-		u8g2centerText(loader[i%4], 80, 10, 32, 32); // "\u00BB\u00AB" // // dice: "\u2685"
-		display.display();
-		delay(100);
-	}
+void OmxDisp::drawLoading()
+{
+    const char *loader[] = {"\u25f0", "\u25f1", "\u25f2", "\u25f3"};
+    display.clearDisplay();
+    u8g2_display.setFontMode(0);
+    for (int16_t i = 0; i < 16; i += 1)
+    {
+        display.clearDisplay();
+        u8g2_display.setCursor(18, 18);
+        u8g2_display.setFont(FONT_TENFAT);
+        u8g2_display.print("OMX-27");
+        u8g2_display.setFont(FONT_SYMB_BIG);
+        u8g2centerText(loader[i % 4], 80, 10, 32, 32); // "\u00BB\u00AB" // // dice: "\u2685"
+        display.display();
+        delay(100);
+    }
 
-	delay(100);
+    delay(100);
 }
 
-
-void OmxDisp::dispGridBoxes(){
-	display.fillRect(0, 0, gridw, 10, WHITE);
-	display.drawFastVLine(gridw/4, 0, gridh, INVERSE);
-	display.drawFastVLine(gridw/2, 0, gridh, INVERSE);
-	display.drawFastVLine(gridw*0.75, 0, gridh, INVERSE);
+void OmxDisp::dispGridBoxes()
+{
+    display.fillRect(0, 0, gridw, 10, WHITE);
+    display.drawFastVLine(gridw / 4, 0, gridh, INVERSE);
+    display.drawFastVLine(gridw / 2, 0, gridh, INVERSE);
+    display.drawFastVLine(gridw * 0.75, 0, gridh, INVERSE);
 }
-void OmxDisp::invertColor(bool flip){
-	if (flip) {
-		u8g2_display.setForegroundColor(BLACK);
-		u8g2_display.setBackgroundColor(WHITE);
-	} else {
-		u8g2_display.setForegroundColor(WHITE);
-		u8g2_display.setBackgroundColor(BLACK);
-	}
+void OmxDisp::invertColor(bool flip)
+{
+    if (flip)
+    {
+        u8g2_display.setForegroundColor(BLACK);
+        u8g2_display.setBackgroundColor(WHITE);
+    }
+    else
+    {
+        u8g2_display.setForegroundColor(WHITE);
+        u8g2_display.setBackgroundColor(BLACK);
+    }
 }
-void OmxDisp::dispValBox(int v, int16_t n, bool inv){			// n is box 0-3
-	invertColor(inv);
-	u8g2centerNumber(v, n*32, hline*2+3, 32, 22);
+void OmxDisp::dispValBox(int v, int16_t n, bool inv)
+{ // n is box 0-3
+    invertColor(inv);
+    u8g2centerNumber(v, n * 32, hline * 2 + 3, 32, 22);
 }
 
-void OmxDisp::dispSymbBox(const char* v, int16_t n, bool inv){			// n is box 0-3
-	invertColor(inv);
-	u8g2centerText(v, n*32, hline*2+3, 32, 22);
+void OmxDisp::dispSymbBox(const char *v, int16_t n, bool inv)
+{ // n is box 0-3
+    invertColor(inv);
+    u8g2centerText(v, n * 32, hline * 2 + 3, 32, 22);
 }
 
-void OmxDisp::setSubmode(int submode) {
-    switch(submode){
-		case SUBMODE_MIDI:
-//			if (midiRoundRobin) {
-//				displaychan = rrChannel;
-//			}
-			legends[0] = "OCT";
-			legends[1] = "CH";
-			legends[2] = "CC";
-			legends[3] = "NOTE";
-			legendVals[0] = (int)midiSettings.octave+4;
-			legendVals[1] = sysSettings.midiChannel;
-			legendVals[2] = potSettings.potVal;
-			legendVals[3] = midiSettings.midiLastNote;
-			dispPage = 1;
-			break;
-		case SUBMODE_MIDI2:
-			legends[0] = "RR";
-			legends[1] = "RROF";
-			legends[2] = "PGM";
-			legends[3] = "BNK";
-			legendVals[0] = midiSettings.midiRRChannelCount;
-			legendVals[1] = midiSettings.midiRRChannelOffset;
-			legendVals[2] = midiSettings.currpgm + 1;
-			legendVals[3] = midiSettings.currbank;
-			dispPage = 2;
-			break;
-		case SUBMODE_MIDI3:
-			legends[0] = "PBNK";	// Potentiometer Banks
-			legends[1] = "THRU";	// MIDI thru (usb to hardware)
-			legends[2] = "MCRO";	// Macro mode
-			legends[3] = "M-CH";
-			legendVals[0] = potSettings.potbank + 1;
-			legendVals[1] = -127;
-			if (midiSettings.midiSoftThru) {
-				legendText[1] = "On";
-			} else {
-				legendText[1] = "Off";
-			}			
-			legendVals[2] = -127;
-			legendText[2] = macromodes[midiMacroConfig.midiMacro];
-			legendVals[3] = midiMacroConfig.midiMacroChan;
-			dispPage = 3;
-			break;
-		case SUBMODE_MIDI4:
-			legends[0] = " BG ";	
-			legends[1] = "---";
-			legends[2] = "---";
-			legends[3] = "---";
-			legendVals[0] = 0;
-			legendVals[1] = 0;
-			legendVals[2] = 0;
-			legendVals[3] = 0;
-			dispPage = 4;
-			break;
-		case SUBMODE_SEQ:
-			// legends[0] = "PTN";
-			// legends[1] = "TRSP";
-			// legends[2] = "SWNG"; //"TRSP";
-			// legends[3] = "BPM";
-			// legendVals[0] = sequencer.playingPattern + 1;
-			// legendVals[1] = (int)transpose;
-			// legendVals[2] = (int)sequencer.getCurrentPattern()->swing; //(int)swing;
-			// // legendVals[2] =  swing_values[sequencer.getCurrentPattern()->swing];
-			// legendVals[3] = (int)clockbpm;
-			// dispPage = 1;
-			break;
-		case SUBMODE_SEQ2:
-			// legends[0] = "SOLO";
-			// legends[1] = "LEN";
-			// legends[2] = "RATE";
-			// legends[3] = "CV"; //cvPattern
-			// legendVals[0] = sequencer.getCurrentPattern()->solo; // playingPattern+1;
-			// legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
-			// legendVals[2] = -127;
-			// legendText[2] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
+void OmxDisp::setSubmode(int submode)
+{
+    switch (submode)
+    {
+    case SUBMODE_MIDI:
+        //			if (midiRoundRobin) {
+        //				displaychan = rrChannel;
+        //			}
+        legends[0] = "OCT";
+        legends[1] = "CH";
+        legends[2] = "CC";
+        legends[3] = "NOTE";
+        legendVals[0] = (int)midiSettings.octave + 4;
+        legendVals[1] = sysSettings.midiChannel;
+        legendVals[2] = potSettings.potVal;
+        legendVals[3] = midiSettings.midiLastNote;
+        dispPage = 1;
+        break;
+    case SUBMODE_MIDI2:
+        legends[0] = "RR";
+        legends[1] = "RROF";
+        legends[2] = "PGM";
+        legends[3] = "BNK";
+        legendVals[0] = midiSettings.midiRRChannelCount;
+        legendVals[1] = midiSettings.midiRRChannelOffset;
+        legendVals[2] = midiSettings.currpgm + 1;
+        legendVals[3] = midiSettings.currbank;
+        dispPage = 2;
+        break;
+    case SUBMODE_MIDI3:
+        legends[0] = "PBNK"; // Potentiometer Banks
+        legends[1] = "THRU"; // MIDI thru (usb to hardware)
+        legends[2] = "MCRO"; // Macro mode
+        legends[3] = "M-CH";
+        legendVals[0] = potSettings.potbank + 1;
+        legendVals[1] = -127;
+        if (midiSettings.midiSoftThru)
+        {
+            legendText[1] = "On";
+        }
+        else
+        {
+            legendText[1] = "Off";
+        }
+        legendVals[2] = -127;
+        legendText[2] = macromodes[midiMacroConfig.midiMacro];
+        legendVals[3] = midiMacroConfig.midiMacroChan;
+        dispPage = 3;
+        break;
+    case SUBMODE_MIDI4:
+        legends[0] = " BG ";
+        legends[1] = "---";
+        legends[2] = "---";
+        legends[3] = "---";
+        legendVals[0] = 0;
+        legendVals[1] = 0;
+        legendVals[2] = 0;
+        legendVals[3] = 0;
+        dispPage = 4;
+        break;
+    case SUBMODE_SEQ:
+        // legends[0] = "PTN";
+        // legends[1] = "TRSP";
+        // legends[2] = "SWNG"; //"TRSP";
+        // legends[3] = "BPM";
+        // legendVals[0] = sequencer.playingPattern + 1;
+        // legendVals[1] = (int)transpose;
+        // legendVals[2] = (int)sequencer.getCurrentPattern()->swing; //(int)swing;
+        // // legendVals[2] =  swing_values[sequencer.getCurrentPattern()->swing];
+        // legendVals[3] = (int)clockbpm;
+        // dispPage = 1;
+        break;
+    case SUBMODE_SEQ2:
+        // legends[0] = "SOLO";
+        // legends[1] = "LEN";
+        // legends[2] = "RATE";
+        // legends[3] = "CV"; //cvPattern
+        // legendVals[0] = sequencer.getCurrentPattern()->solo; // playingPattern+1;
+        // legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
+        // legendVals[2] = -127;
+        // legendText[2] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
 
-			// legendVals[3] = -127;
-			// if (sequencer.getCurrentPattern()->sendCV) {
-			// 	legendText[3] = "On";
-			// } else {
-			// 	legendText[3] = "Off";
-			// }
-			// dispPage = 2;
-			break;
-		case SUBMODE_PATTPARAMS:
-			// legends[0] = "PTN";
-			// legends[1] = "LEN";
-			// legends[2] = "ROT";
-			// legends[3] = "CHAN";
-			// legendVals[0] = sequencer.playingPattern + 1;
-			// legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
-			// legendVals[2] = rotationAmt; //(int)transpose;
-			// legendVals[3] = sequencer.getPatternChannel(sequencer.playingPattern);
-			// dispPage = 1;
-			break;
-		case SUBMODE_PATTPARAMS2:
-			// legends[0] = "START";
-			// legends[1] = "END";
-			// legends[2] = "FREQ";
-			// legends[3] = "PROB";
-			// legendVals[0] = sequencer.getCurrentPattern()->startstep + 1;			// STRT step to autoreset on
-			// legendVals[1] = sequencer.getCurrentPattern()->autoresetstep;			// STP step to autoreset on - 0 = no auto reset
-			// legendVals[2] = sequencer.getCurrentPattern()->autoresetfreq; 			// FRQ to autoreset on -- every x cycles
-			// legendVals[3] = sequencer.getCurrentPattern()->autoresetprob;			// PRO probability of resetting 0=NEVER 1=Always 2=50%
-			// dispPage = 2;
-			break;
-		case SUBMODE_PATTPARAMS3:
-			// legends[0] = "RATE";
-			// legends[1] = "SOLO";
-			// legends[2] = "---";
-			// legends[3] = "---";
+        // legendVals[3] = -127;
+        // if (sequencer.getCurrentPattern()->sendCV) {
+        // 	legendText[3] = "On";
+        // } else {
+        // 	legendText[3] = "Off";
+        // }
+        // dispPage = 2;
+        break;
+    case SUBMODE_PATTPARAMS:
+        // legends[0] = "PTN";
+        // legends[1] = "LEN";
+        // legends[2] = "ROT";
+        // legends[3] = "CHAN";
+        // legendVals[0] = sequencer.playingPattern + 1;
+        // legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
+        // legendVals[2] = rotationAmt; //(int)transpose;
+        // legendVals[3] = sequencer.getPatternChannel(sequencer.playingPattern);
+        // dispPage = 1;
+        break;
+    case SUBMODE_PATTPARAMS2:
+        // legends[0] = "START";
+        // legends[1] = "END";
+        // legends[2] = "FREQ";
+        // legends[3] = "PROB";
+        // legendVals[0] = sequencer.getCurrentPattern()->startstep + 1;			// STRT step to autoreset on
+        // legendVals[1] = sequencer.getCurrentPattern()->autoresetstep;			// STP step to autoreset on - 0 = no auto reset
+        // legendVals[2] = sequencer.getCurrentPattern()->autoresetfreq; 			// FRQ to autoreset on -- every x cycles
+        // legendVals[3] = sequencer.getCurrentPattern()->autoresetprob;			// PRO probability of resetting 0=NEVER 1=Always 2=50%
+        // dispPage = 2;
+        break;
+    case SUBMODE_PATTPARAMS3:
+        // legends[0] = "RATE";
+        // legends[1] = "SOLO";
+        // legends[2] = "---";
+        // legends[3] = "---";
 
-			// // RATE FOR CURR PATTERN
-			// legendVals[0] = -127;
-			// legendText[0] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
+        // // RATE FOR CURR PATTERN
+        // legendVals[0] = -127;
+        // legendText[0] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
 
-			// legendVals[1] = sequencer.getCurrentPattern()->solo;
-			// legendVals[2] = 0; 			// TBD
-			// legendVals[3] = 0;			// TBD
-			// dispPage = 3;
-			break;
-		case SUBMODE_STEPREC:
-			// legends[0] = "OCT";
-			// legends[1] = "STEP";
-			// legends[2] = "NOTE";
-			// legends[3] = "PTN";
-			// legendVals[0] = (int)octave+4;
-			// legendVals[1] = sequencer.seqPos[sequencer.playingPattern]+1;
-			// legendVals[2] = getSelectedStep()->note; //(int)transpose;
-			// legendVals[3] = sequencer.playingPattern+1;
-			// dispPage = 1;
-			break;
-		case SUBMODE_NOTESEL:
-			// legends[0] = "NOTE";
-			// legends[1] = "OCT";
-			// legends[2] = "VEL";
-			// legends[3] = "LEN";
-			// legendVals[0] = getSelectedStep()->note;
-			// legendVals[1] = (int)octave+4;
-			// legendVals[2] = getSelectedStep()->vel;
-			// legendVals[3] = getSelectedStep()->len + 1;
-			// dispPage = 1;
-			break;
-		case SUBMODE_NOTESEL2:
-// 			legends[0] = "TYPE";
-// 			legends[1] = "PROB";
-// 			legends[2] = "COND";
-// 			legends[3] = "";
-// 			legendVals[0] = -127;
-// 			legendText[0] = stepTypes[getSelectedStep()->stepType];
-// 			legendVals[1] = getSelectedStep()->prob;
-// //				String ac = String(trigConditionsAB[][0]);
-// //				String bc = String(trigConditionsAB[getSelectedStep()->condition][1]);
+        // legendVals[1] = sequencer.getCurrentPattern()->solo;
+        // legendVals[2] = 0; 			// TBD
+        // legendVals[3] = 0;			// TBD
+        // dispPage = 3;
+        break;
+    case SUBMODE_STEPREC:
+        // legends[0] = "OCT";
+        // legends[1] = "STEP";
+        // legends[2] = "NOTE";
+        // legends[3] = "PTN";
+        // legendVals[0] = (int)octave+4;
+        // legendVals[1] = sequencer.seqPos[sequencer.playingPattern]+1;
+        // legendVals[2] = getSelectedStep()->note; //(int)transpose;
+        // legendVals[3] = sequencer.playingPattern+1;
+        // dispPage = 1;
+        break;
+    case SUBMODE_NOTESEL:
+        // legends[0] = "NOTE";
+        // legends[1] = "OCT";
+        // legends[2] = "VEL";
+        // legends[3] = "LEN";
+        // legendVals[0] = getSelectedStep()->note;
+        // legendVals[1] = (int)octave+4;
+        // legendVals[2] = getSelectedStep()->vel;
+        // legendVals[3] = getSelectedStep()->len + 1;
+        // dispPage = 1;
+        break;
+    case SUBMODE_NOTESEL2:
+        // 			legends[0] = "TYPE";
+        // 			legends[1] = "PROB";
+        // 			legends[2] = "COND";
+        // 			legends[3] = "";
+        // 			legendVals[0] = -127;
+        // 			legendText[0] = stepTypes[getSelectedStep()->stepType];
+        // 			legendVals[1] = getSelectedStep()->prob;
+        // //				String ac = String(trigConditionsAB[][0]);
+        // //				String bc = String(trigConditionsAB[getSelectedStep()->condition][1]);
 
-// 			legendVals[2] = -127;
-// 			legendText[2] = trigConditions[getSelectedStep()->condition]; //ac + bc; // trigConditions
+        // 			legendVals[2] = -127;
+        // 			legendText[2] = trigConditions[getSelectedStep()->condition]; //ac + bc; // trigConditions
 
-// 			legendVals[3] = 0;
-// 			dispPage = 2;
-			break;
-		case SUBMODE_NOTESEL3:
-			// legends[0] = "L-1";
-			// legends[1] = "L-2";
-			// legends[2] = "L-3";
-			// legends[3] = "L-4";
-			// for (int j=0; j<4; j++){
-			// 	int stepNoteParam = getSelectedStep()->params[j];
-			// 	if (stepNoteParam > -1){
-			// 		legendVals[j] = stepNoteParam;
-			// 	} else {
-			// 		legendVals[j] = -127;
-			// 		legendText[j] = "---";
-			// 	}
-			// }
-			// dispPage = 3;
-			break;
+        // 			legendVals[3] = 0;
+        // 			dispPage = 2;
+        break;
+    case SUBMODE_NOTESEL3:
+        // legends[0] = "L-1";
+        // legends[1] = "L-2";
+        // legends[2] = "L-3";
+        // legends[3] = "L-4";
+        // for (int j=0; j<4; j++){
+        // 	int stepNoteParam = getSelectedStep()->params[j];
+        // 	if (stepNoteParam > -1){
+        // 		legendVals[j] = stepNoteParam;
+        // 	} else {
+        // 		legendVals[j] = -127;
+        // 		legendText[j] = "---";
+        // 	}
+        // }
+        // dispPage = 3;
+        break;
 
-		default:
-			break;
-	}
+    default:
+        break;
+    }
 }
 
 void OmxDisp::clearLegends()
@@ -330,105 +348,158 @@ void OmxDisp::clearLegends()
     legendText[3] = "";
 }
 
-void OmxDisp::dispGenericMode(int submode, int selected){
-	// const char* legends[4] = {"","","",""};
-	// int legendVals[4] = {0,0,0,0};
-	// int dispPage = 0;
-	// const char* legendText[4] = {"","","",""};
-//	int displaychan = sysSettings.midiChannel;
+void OmxDisp::dispGenericMode(int submode, int selected)
+{
+    // const char* legends[4] = {"","","",""};
+    // int legendVals[4] = {0,0,0,0};
+    // int dispPage = 0;
+    // const char* legendText[4] = {"","","",""};
+    //	int displaychan = sysSettings.midiChannel;
 
-	u8g2_display.setFontMode(1);
-	u8g2_display.setFont(FONT_LABELS);
-	u8g2_display.setCursor(0, 0);
-	dispGridBoxes();
+    u8g2_display.setFontMode(1);
+    u8g2_display.setFont(FONT_LABELS);
+    u8g2_display.setCursor(0, 0);
+    dispGridBoxes();
 
-	// labels
-	u8g2_display.setForegroundColor(BLACK);
-	u8g2_display.setBackgroundColor(WHITE);
+    // labels
+    u8g2_display.setForegroundColor(BLACK);
+    u8g2_display.setBackgroundColor(WHITE);
 
-	for (int j= 0; j<4; j++){
-		u8g2centerText(legends[j], (j*32) + 1, hline-2, 32, 10);
-	}
+    for (int j = 0; j < 4; j++)
+    {
+        u8g2centerText(legends[j], (j * 32) + 1, hline - 2, 32, 10);
+    }
 
-	// value text formatting
-	u8g2_display.setFontMode(1);
-	u8g2_display.setFont(FONT_VALUES);
-	u8g2_display.setForegroundColor(WHITE);
-	u8g2_display.setBackgroundColor(BLACK);
+    // value text formatting
+    u8g2_display.setFontMode(1);
+    u8g2_display.setFont(FONT_VALUES);
+    u8g2_display.setForegroundColor(WHITE);
+    u8g2_display.setBackgroundColor(BLACK);
 
+    switch (selected)
+    {
+    case 1:
+        display.fillRect(0 * 32 + 2, 9, 29, 21, WHITE);
+        break;
+    case 2: //
+        display.fillRect(1 * 32 + 2, 9, 29, 21, WHITE);
+        break;
+    case 3: //
+        display.fillRect(2 * 32 + 2, 9, 29, 21, WHITE);
+        break;
+    case 4: //
+        display.fillRect(3 * 32 + 2, 9, 29, 21, WHITE);
+        break;
+    case 0:
+    default:
+        break;
+    }
+    // ValueBoxes
+    int highlight = false;
+    for (int j = 1; j < NUM_DISP_PARAMS; j++)
+    { // start at 1 to only highlight values 1-4
 
-	switch(selected){
-		case 1:
-			display.fillRect(0*32+2, 9, 29, 21, WHITE);
-			break;
-		case 2: 	//
-			display.fillRect(1*32+2, 9, 29, 21, WHITE);
-			break;
-		case 3: 	//
-			display.fillRect(2*32+2, 9, 29, 21, WHITE);
-			break;
-		case 4: 	//
-			display.fillRect(3*32+2, 9, 29, 21, WHITE);
-			break;
-		case 0:
-		default:
-			break;
-	}
-	// ValueBoxes
-	int highlight = false;
-	for (int j = 1; j < NUM_DISP_PARAMS; j++){ // start at 1 to only highlight values 1-4
-
-		if (j == selected) {
-			highlight = true;
-		}else{
-			highlight = false;
-		}
-		if (legendVals[j-1] == -127){
-			dispSymbBox(legendText[j-1], j-1, highlight);
-		} else {
-			dispValBox(legendVals[j-1], j-1, highlight);
-		}
-	}
-	if (dispPage != 0) {
-		for (int k=0; k<4; k++){
-			if (dispPage == k+1){
-				dispPageIndicators(k, true);
-			} else {
-				dispPageIndicators(k, false);
-			}
-		}
-	}
-
+        if (j == selected)
+        {
+            highlight = true;
+        }
+        else
+        {
+            highlight = false;
+        }
+        if (legendVals[j - 1] == -127)
+        {
+            dispSymbBox(legendText[j - 1], j - 1, highlight);
+        }
+        else
+        {
+            dispValBox(legendVals[j - 1], j - 1, highlight);
+        }
+    }
+    if (dispPage != 0)
+    {
+        for (int k = 0; k < 4; k++)
+        {
+            if (dispPage == k + 1)
+            {
+                dispPageIndicators(k, true);
+            }
+            else
+            {
+                dispPageIndicators(k, false);
+            }
+        }
+    }
 }
 
-void OmxDisp::dispPageIndicators(int page, bool selected){
-	if (selected){
-		display.fillRect(43 + (page * 12), 30, 6, 2, WHITE);
-	} else {
-		display.fillRect(43 + (page * 12), 31, 6, 1, WHITE);
-	}
+void OmxDisp::dispPageIndicators(int page, bool selected)
+{
+    if (selected)
+    {
+        display.fillRect(43 + (page * 12), 30, 6, 2, WHITE);
+    }
+    else
+    {
+        display.fillRect(43 + (page * 12), 31, 6, 1, WHITE);
+    }
 }
 
-void OmxDisp::dispMode(){
-	// labels formatting
-	u8g2_display.setFontMode(1);
-	u8g2_display.setFont(FONT_BIG);
-	u8g2_display.setCursor(0, 0);
+void OmxDisp::dispMode()
+{
+    // labels formatting
+    u8g2_display.setFontMode(1);
+    u8g2_display.setFont(FONT_BIG);
+    u8g2_display.setCursor(0, 0);
 
-	u8g2_display.setForegroundColor(WHITE);
-	u8g2_display.setBackgroundColor(BLACK);
+    u8g2_display.setForegroundColor(WHITE);
+    u8g2_display.setBackgroundColor(BLACK);
 
-	const char* displaymode = "";
-	if (sysSettings.newmode != sysSettings.omxMode && enc_edit) {
-		displaymode = modes[sysSettings.newmode]; // display.print(modes[sysSettings.newmode]);
-	} else if (enc_edit) {
-		displaymode = modes[sysSettings.omxMode]; // display.print(modes[mode]);
-	}
-	u8g2centerText(displaymode, 86, 20, 44, 32);
+    const char *displaymode = "";
+    if (sysSettings.newmode != sysSettings.omxMode && encoderConfig.enc_edit)
+    {
+        displaymode = modes[sysSettings.newmode]; // display.print(modes[sysSettings.newmode]);
+    }
+    else if (encoderConfig.enc_edit)
+    {
+        displaymode = modes[sysSettings.omxMode]; // display.print(modes[mode]);
+    }
+    u8g2centerText(displaymode, 86, 20, 44, 32);
 }
 
-void OmxDisp::setDispDirty(){
+void OmxDisp::setDirty()
+{
     dirtyDisplay = true;
 }
 
-extern OmxDisp omxidsp;
+void OmxDisp::UpdateMessageTextTimer()
+{
+    if (messageTextTimer > 0)
+    {
+        messageTextTimer -= sysSettings.timeElasped;
+        if (messageTextTimer <= 0)
+        {
+            setDirty();
+            messageTextTimer = 0;
+        }
+    }
+}
+
+void OmxDisp::showDisplay()
+{
+    if (dirtyDisplay)
+    {
+        if (dirtyDisplayTimer > displayRefreshRate)
+        {
+            display.display();
+            dirtyDisplay = false;
+            dirtyDisplayTimer = 0;
+        }
+    }
+}
+
+void OmxDisp::bumpDisplayTimer()
+{
+    dirtyDisplayTimer = displayRefreshRate + 1;
+}
+
+OmxDisp omxDisp;

--- a/OMX-27-firmware/omx_disp.cpp
+++ b/OMX-27-firmware/omx_disp.cpp
@@ -1,0 +1,434 @@
+#include <U8g2_for_Adafruit_GFX.h>
+
+#include "omx_disp.h"
+#include "consts.h"
+#include "ClearUI.h"
+#include "omx_midi_settings.h"
+
+U8G2_FOR_ADAFRUIT_GFX u8g2_display;
+
+// Constructor
+OmxDisp::OmxDisp()
+{
+}
+
+void OmxDisp::setup() {
+    initializeDisplay();
+	u8g2_display.begin(display);
+}
+
+void OmxDisp::clearDisplay(){
+    // Clear display
+	display.display();
+	dirtyDisplay = true;
+}
+
+
+void OmxDisp::drawStartupScreen(){
+    display.clearDisplay();
+	testdrawrect();
+	delay(200);
+	display.clearDisplay();
+	u8g2_display.setForegroundColor(WHITE);
+	u8g2_display.setBackgroundColor(BLACK);
+	drawLoading();
+}
+
+void OmxDisp::displayMessage(const char* msg) {
+    display.fillRect(0, 0, 128, 32, BLACK);
+    u8g2_display.setFontMode(1);
+    u8g2_display.setFont(FONT_TENFAT);
+    u8g2_display.setForegroundColor(WHITE);
+    u8g2_display.setBackgroundColor(BLACK);
+    u8g2centerText(msg, 0, 10, 128, 32);
+
+    messageTextTimer = MESSAGE_TIMEOUT_US;
+    dirtyDisplay = true;
+}
+
+void OmxDisp::displayMessagef(const char* fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buf[24];
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    displayMessage(buf);
+}
+
+void OmxDisp::u8g2centerText(const char* s, int16_t x, int16_t y, uint16_t w, uint16_t h) {
+//  int16_t bx, by;
+	uint16_t bw, bh;
+	bw = u8g2_display.getUTF8Width(s);
+	bh = u8g2_display.getFontAscent();
+	u8g2_display.setCursor(
+		x + (w - bw) / 2,
+		y + (h - bh) / 2
+	);
+	u8g2_display.print(s);
+}
+
+void OmxDisp::u8g2centerNumber(int n, uint16_t x, uint16_t y, uint16_t w, uint16_t h)
+{
+	char buf[8];
+	itoa(n, buf, 10);
+	u8g2centerText(buf, x, y, w, h);
+}
+
+void OmxDisp::testdrawrect() {
+	display.clearDisplay();
+
+	for(int16_t i=0; i<display.height()/2; i+=2) {
+		display.drawRect(i, i, display.width()-2*i, display.height()-2*i, SSD1306_WHITE);
+		display.display(); // Update screen with each newly-drawn rectangle
+		delay(1);
+	}
+
+	delay(500);
+}
+
+void OmxDisp::drawLoading() {
+	const char* loader[] = {"\u25f0", "\u25f1", "\u25f2", "\u25f3"};
+	display.clearDisplay();
+	u8g2_display.setFontMode(0);
+	for(int16_t i=0; i<16; i+=1) {
+		display.clearDisplay();
+		u8g2_display.setCursor(18,18);
+		u8g2_display.setFont(FONT_TENFAT);
+		u8g2_display.print("OMX-27");
+		u8g2_display.setFont(FONT_SYMB_BIG);
+		u8g2centerText(loader[i%4], 80, 10, 32, 32); // "\u00BB\u00AB" // // dice: "\u2685"
+		display.display();
+		delay(100);
+	}
+
+	delay(100);
+}
+
+
+void OmxDisp::dispGridBoxes(){
+	display.fillRect(0, 0, gridw, 10, WHITE);
+	display.drawFastVLine(gridw/4, 0, gridh, INVERSE);
+	display.drawFastVLine(gridw/2, 0, gridh, INVERSE);
+	display.drawFastVLine(gridw*0.75, 0, gridh, INVERSE);
+}
+void OmxDisp::invertColor(bool flip){
+	if (flip) {
+		u8g2_display.setForegroundColor(BLACK);
+		u8g2_display.setBackgroundColor(WHITE);
+	} else {
+		u8g2_display.setForegroundColor(WHITE);
+		u8g2_display.setBackgroundColor(BLACK);
+	}
+}
+void OmxDisp::dispValBox(int v, int16_t n, bool inv){			// n is box 0-3
+	invertColor(inv);
+	u8g2centerNumber(v, n*32, hline*2+3, 32, 22);
+}
+
+void OmxDisp::dispSymbBox(const char* v, int16_t n, bool inv){			// n is box 0-3
+	invertColor(inv);
+	u8g2centerText(v, n*32, hline*2+3, 32, 22);
+}
+
+void OmxDisp::setSubmode(int submode) {
+    switch(submode){
+		case SUBMODE_MIDI:
+//			if (midiRoundRobin) {
+//				displaychan = rrChannel;
+//			}
+			legends[0] = "OCT";
+			legends[1] = "CH";
+			legends[2] = "CC";
+			legends[3] = "NOTE";
+			legendVals[0] = (int)midiSettings.octave+4;
+			legendVals[1] = sysSettings.midiChannel;
+			legendVals[2] = potSettings.potVal;
+			legendVals[3] = midiSettings.midiLastNote;
+			dispPage = 1;
+			break;
+		case SUBMODE_MIDI2:
+			legends[0] = "RR";
+			legends[1] = "RROF";
+			legends[2] = "PGM";
+			legends[3] = "BNK";
+			legendVals[0] = midiSettings.midiRRChannelCount;
+			legendVals[1] = midiSettings.midiRRChannelOffset;
+			legendVals[2] = midiSettings.currpgm + 1;
+			legendVals[3] = midiSettings.currbank;
+			dispPage = 2;
+			break;
+		case SUBMODE_MIDI3:
+			legends[0] = "PBNK";	// Potentiometer Banks
+			legends[1] = "THRU";	// MIDI thru (usb to hardware)
+			legends[2] = "MCRO";	// Macro mode
+			legends[3] = "M-CH";
+			legendVals[0] = potSettings.potbank + 1;
+			legendVals[1] = -127;
+			if (midiSettings.midiSoftThru) {
+				legendText[1] = "On";
+			} else {
+				legendText[1] = "Off";
+			}			
+			legendVals[2] = -127;
+			legendText[2] = macromodes[midiMacroConfig.midiMacro];
+			legendVals[3] = midiMacroConfig.midiMacroChan;
+			dispPage = 3;
+			break;
+		case SUBMODE_MIDI4:
+			legends[0] = " BG ";	
+			legends[1] = "---";
+			legends[2] = "---";
+			legends[3] = "---";
+			legendVals[0] = 0;
+			legendVals[1] = 0;
+			legendVals[2] = 0;
+			legendVals[3] = 0;
+			dispPage = 4;
+			break;
+		case SUBMODE_SEQ:
+			// legends[0] = "PTN";
+			// legends[1] = "TRSP";
+			// legends[2] = "SWNG"; //"TRSP";
+			// legends[3] = "BPM";
+			// legendVals[0] = sequencer.playingPattern + 1;
+			// legendVals[1] = (int)transpose;
+			// legendVals[2] = (int)sequencer.getCurrentPattern()->swing; //(int)swing;
+			// // legendVals[2] =  swing_values[sequencer.getCurrentPattern()->swing];
+			// legendVals[3] = (int)clockbpm;
+			// dispPage = 1;
+			break;
+		case SUBMODE_SEQ2:
+			// legends[0] = "SOLO";
+			// legends[1] = "LEN";
+			// legends[2] = "RATE";
+			// legends[3] = "CV"; //cvPattern
+			// legendVals[0] = sequencer.getCurrentPattern()->solo; // playingPattern+1;
+			// legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
+			// legendVals[2] = -127;
+			// legendText[2] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
+
+			// legendVals[3] = -127;
+			// if (sequencer.getCurrentPattern()->sendCV) {
+			// 	legendText[3] = "On";
+			// } else {
+			// 	legendText[3] = "Off";
+			// }
+			// dispPage = 2;
+			break;
+		case SUBMODE_PATTPARAMS:
+			// legends[0] = "PTN";
+			// legends[1] = "LEN";
+			// legends[2] = "ROT";
+			// legends[3] = "CHAN";
+			// legendVals[0] = sequencer.playingPattern + 1;
+			// legendVals[1] = sequencer.getPatternLength(sequencer.playingPattern);
+			// legendVals[2] = rotationAmt; //(int)transpose;
+			// legendVals[3] = sequencer.getPatternChannel(sequencer.playingPattern);
+			// dispPage = 1;
+			break;
+		case SUBMODE_PATTPARAMS2:
+			// legends[0] = "START";
+			// legends[1] = "END";
+			// legends[2] = "FREQ";
+			// legends[3] = "PROB";
+			// legendVals[0] = sequencer.getCurrentPattern()->startstep + 1;			// STRT step to autoreset on
+			// legendVals[1] = sequencer.getCurrentPattern()->autoresetstep;			// STP step to autoreset on - 0 = no auto reset
+			// legendVals[2] = sequencer.getCurrentPattern()->autoresetfreq; 			// FRQ to autoreset on -- every x cycles
+			// legendVals[3] = sequencer.getCurrentPattern()->autoresetprob;			// PRO probability of resetting 0=NEVER 1=Always 2=50%
+			// dispPage = 2;
+			break;
+		case SUBMODE_PATTPARAMS3:
+			// legends[0] = "RATE";
+			// legends[1] = "SOLO";
+			// legends[2] = "---";
+			// legends[3] = "---";
+
+			// // RATE FOR CURR PATTERN
+			// legendVals[0] = -127;
+			// legendText[0] = mdivs[sequencer.getCurrentPattern()->clockDivMultP];
+
+			// legendVals[1] = sequencer.getCurrentPattern()->solo;
+			// legendVals[2] = 0; 			// TBD
+			// legendVals[3] = 0;			// TBD
+			// dispPage = 3;
+			break;
+		case SUBMODE_STEPREC:
+			// legends[0] = "OCT";
+			// legends[1] = "STEP";
+			// legends[2] = "NOTE";
+			// legends[3] = "PTN";
+			// legendVals[0] = (int)octave+4;
+			// legendVals[1] = sequencer.seqPos[sequencer.playingPattern]+1;
+			// legendVals[2] = getSelectedStep()->note; //(int)transpose;
+			// legendVals[3] = sequencer.playingPattern+1;
+			// dispPage = 1;
+			break;
+		case SUBMODE_NOTESEL:
+			// legends[0] = "NOTE";
+			// legends[1] = "OCT";
+			// legends[2] = "VEL";
+			// legends[3] = "LEN";
+			// legendVals[0] = getSelectedStep()->note;
+			// legendVals[1] = (int)octave+4;
+			// legendVals[2] = getSelectedStep()->vel;
+			// legendVals[3] = getSelectedStep()->len + 1;
+			// dispPage = 1;
+			break;
+		case SUBMODE_NOTESEL2:
+// 			legends[0] = "TYPE";
+// 			legends[1] = "PROB";
+// 			legends[2] = "COND";
+// 			legends[3] = "";
+// 			legendVals[0] = -127;
+// 			legendText[0] = stepTypes[getSelectedStep()->stepType];
+// 			legendVals[1] = getSelectedStep()->prob;
+// //				String ac = String(trigConditionsAB[][0]);
+// //				String bc = String(trigConditionsAB[getSelectedStep()->condition][1]);
+
+// 			legendVals[2] = -127;
+// 			legendText[2] = trigConditions[getSelectedStep()->condition]; //ac + bc; // trigConditions
+
+// 			legendVals[3] = 0;
+// 			dispPage = 2;
+			break;
+		case SUBMODE_NOTESEL3:
+			// legends[0] = "L-1";
+			// legends[1] = "L-2";
+			// legends[2] = "L-3";
+			// legends[3] = "L-4";
+			// for (int j=0; j<4; j++){
+			// 	int stepNoteParam = getSelectedStep()->params[j];
+			// 	if (stepNoteParam > -1){
+			// 		legendVals[j] = stepNoteParam;
+			// 	} else {
+			// 		legendVals[j] = -127;
+			// 		legendText[j] = "---";
+			// 	}
+			// }
+			// dispPage = 3;
+			break;
+
+		default:
+			break;
+	}
+}
+
+void OmxDisp::clearLegends()
+{
+    legends[0] = "";
+    legends[1] = "";
+    legends[2] = "";
+    legends[3] = "";
+    legendVals[0] = 0;
+    legendVals[1] = 0;
+    legendVals[2] = 0;
+    legendVals[3] = 0;
+    dispPage = 0;
+    legendText[0] = "";
+    legendText[1] = "";
+    legendText[2] = "";
+    legendText[3] = "";
+}
+
+void OmxDisp::dispGenericMode(int submode, int selected){
+	// const char* legends[4] = {"","","",""};
+	// int legendVals[4] = {0,0,0,0};
+	// int dispPage = 0;
+	// const char* legendText[4] = {"","","",""};
+//	int displaychan = sysSettings.midiChannel;
+
+	u8g2_display.setFontMode(1);
+	u8g2_display.setFont(FONT_LABELS);
+	u8g2_display.setCursor(0, 0);
+	dispGridBoxes();
+
+	// labels
+	u8g2_display.setForegroundColor(BLACK);
+	u8g2_display.setBackgroundColor(WHITE);
+
+	for (int j= 0; j<4; j++){
+		u8g2centerText(legends[j], (j*32) + 1, hline-2, 32, 10);
+	}
+
+	// value text formatting
+	u8g2_display.setFontMode(1);
+	u8g2_display.setFont(FONT_VALUES);
+	u8g2_display.setForegroundColor(WHITE);
+	u8g2_display.setBackgroundColor(BLACK);
+
+
+	switch(selected){
+		case 1:
+			display.fillRect(0*32+2, 9, 29, 21, WHITE);
+			break;
+		case 2: 	//
+			display.fillRect(1*32+2, 9, 29, 21, WHITE);
+			break;
+		case 3: 	//
+			display.fillRect(2*32+2, 9, 29, 21, WHITE);
+			break;
+		case 4: 	//
+			display.fillRect(3*32+2, 9, 29, 21, WHITE);
+			break;
+		case 0:
+		default:
+			break;
+	}
+	// ValueBoxes
+	int highlight = false;
+	for (int j = 1; j < NUM_DISP_PARAMS; j++){ // start at 1 to only highlight values 1-4
+
+		if (j == selected) {
+			highlight = true;
+		}else{
+			highlight = false;
+		}
+		if (legendVals[j-1] == -127){
+			dispSymbBox(legendText[j-1], j-1, highlight);
+		} else {
+			dispValBox(legendVals[j-1], j-1, highlight);
+		}
+	}
+	if (dispPage != 0) {
+		for (int k=0; k<4; k++){
+			if (dispPage == k+1){
+				dispPageIndicators(k, true);
+			} else {
+				dispPageIndicators(k, false);
+			}
+		}
+	}
+
+}
+
+void OmxDisp::dispPageIndicators(int page, bool selected){
+	if (selected){
+		display.fillRect(43 + (page * 12), 30, 6, 2, WHITE);
+	} else {
+		display.fillRect(43 + (page * 12), 31, 6, 1, WHITE);
+	}
+}
+
+void OmxDisp::dispMode(){
+	// labels formatting
+	u8g2_display.setFontMode(1);
+	u8g2_display.setFont(FONT_BIG);
+	u8g2_display.setCursor(0, 0);
+
+	u8g2_display.setForegroundColor(WHITE);
+	u8g2_display.setBackgroundColor(BLACK);
+
+	const char* displaymode = "";
+	if (sysSettings.newmode != sysSettings.omxMode && enc_edit) {
+		displaymode = modes[sysSettings.newmode]; // display.print(modes[sysSettings.newmode]);
+	} else if (enc_edit) {
+		displaymode = modes[sysSettings.omxMode]; // display.print(modes[mode]);
+	}
+	u8g2centerText(displaymode, 86, 20, 44, 32);
+}
+
+void OmxDisp::setDispDirty(){
+    dirtyDisplay = true;
+}
+
+extern OmxDisp omxidsp;

--- a/OMX-27-firmware/omx_disp.h
+++ b/OMX-27-firmware/omx_disp.h
@@ -20,6 +20,8 @@ public:
     void displayMessage(const char *msg);
     void displayMessagef(const char *fmt, ...);
 
+    bool isMessageActive();
+
     void dispGridBoxes();
     void invertColor(bool flip);
     void dispValBox(int v, int16_t n, bool inv);

--- a/OMX-27-firmware/omx_disp.h
+++ b/OMX-27-firmware/omx_disp.h
@@ -31,17 +31,26 @@ public:
     void testdrawrect();
     void drawLoading();
 
-    void setDispDirty();
+    void setDirty();
+
+    void showDisplay();
+
+    void bumpDisplayTimer();
 
     void clearLegends();
     void setSubmode(int submode);
+
+    void UpdateMessageTextTimer();
 private:
     int hline = 8;
     int messageTextTimer = 0;
     bool dirtyDisplay = false;
 
+    elapsedMillis dirtyDisplayTimer = 0;
+    unsigned long displayRefreshRate = 60;
+
     void u8g2centerText(const char *s, int16_t x, int16_t y, uint16_t w, uint16_t h);
     void u8g2centerNumber(int n, uint16_t x, uint16_t y, uint16_t w, uint16_t h);
 };
 
-extern OmxDisp omxidsp;
+extern OmxDisp omxDisp;

--- a/OMX-27-firmware/omx_disp.h
+++ b/OMX-27-firmware/omx_disp.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "config.h"
+
+// MESSAGE DISPLAY
+const int MESSAGE_TIMEOUT_US = 500000;
+
+class OmxDisp
+{
+public:
+    // Should make into function
+    const char* legends[4] = {"","","",""};
+	int legendVals[4] = {0,0,0,0};
+	int dispPage = 0;
+	const char* legendText[4] = {"","","",""};
+
+    OmxDisp();
+    void setup();
+    void clearDisplay();
+    void drawStartupScreen();
+    void displayMessage(const char *msg);
+    void displayMessagef(const char *fmt, ...);
+
+    void dispGridBoxes();
+    void invertColor(bool flip);
+    void dispValBox(int v, int16_t n, bool inv);
+    void dispSymbBox(const char *v, int16_t n, bool inv);
+    void dispGenericMode(int submode, int selected);
+    void dispPageIndicators(int page, bool selected);
+    void dispMode();
+
+    void testdrawrect();
+    void drawLoading();
+
+    void setDispDirty();
+
+    void clearLegends();
+    void setSubmode(int submode);
+private:
+    int hline = 8;
+    int messageTextTimer = 0;
+    bool dirtyDisplay = false;
+
+    void u8g2centerText(const char *s, int16_t x, int16_t y, uint16_t w, uint16_t h);
+    void u8g2centerNumber(int n, uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+};
+
+extern OmxDisp omxidsp;

--- a/OMX-27-firmware/omx_disp.h
+++ b/OMX-27-firmware/omx_disp.h
@@ -8,10 +8,10 @@ class OmxDisp
 {
 public:
     // Should make into function
-    const char* legends[4] = {"","","",""};
-	int legendVals[4] = {0,0,0,0};
-	int dispPage = 0;
-	const char* legendText[4] = {"","","",""};
+    const char *legends[4] = {"", "", "", ""};
+    int legendVals[4] = {0, 0, 0, 0};
+    int dispPage = 0;
+    const char *legendText[4] = {"", "", "", ""};
 
     OmxDisp();
     void setup();
@@ -24,7 +24,7 @@ public:
     void invertColor(bool flip);
     void dispValBox(int v, int16_t n, bool inv);
     void dispSymbBox(const char *v, int16_t n, bool inv);
-    void dispGenericMode(int submode, int selected);
+    void dispGenericMode(int selected);
     void dispPageIndicators(int page, bool selected);
     void dispMode();
 
@@ -32,6 +32,7 @@ public:
     void drawLoading();
 
     void setDirty();
+    bool isDirty() { return dirtyDisplay; }
 
     void showDisplay();
 
@@ -41,6 +42,7 @@ public:
     void setSubmode(int submode);
 
     void UpdateMessageTextTimer();
+
 private:
     int hline = 8;
     int messageTextTimer = 0;

--- a/OMX-27-firmware/omx_leds.cpp
+++ b/OMX-27-firmware/omx_leds.cpp
@@ -1,5 +1,8 @@
 #include "omx_leds.h"
 #include "consts.h"
+#include "colors.h"
+
+Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 
 //  OmxLeds::OmxLeds(){
 //     Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
@@ -44,12 +47,13 @@ void OmxLeds::updateLeds()
 }
 
 void OmxLeds::drawMidiLeds() {
-	blinkInterval = step_delay*2;
+    updateLeds();
+	// blinkInterval = clockConfig.step_delay*2;
 
-	if (blink_msec >= blinkInterval){
-		blinkState = !blinkState;
-		blink_msec = 0;
-	}
+	// if (blink_msec >= blinkInterval){
+	// 	blinkState = !blinkState;
+	// 	blink_msec = 0;
+	// }
 
 	if (midiSettings.midiAUX){
 		// Blink left/right keys for octave select indicators.
@@ -59,13 +63,13 @@ void OmxLeds::drawMidiLeds() {
 		auto color4 = blinkState ? RBLUE : LEDOFF;
 
 		for (int q = 1; q < LED_COUNT; q++){				
-			if (midiKeyState[q] == -1){
-				if (midiBg_Hue == 0){
+			if (midiSettings.midiKeyState[q] == -1){
+				if (colorConfig.midiBg_Hue == 0){
 					strip.setPixelColor(q, LEDOFF);
-				} else if (midiBg_Hue == 32){
+				} else if (colorConfig.midiBg_Hue == 32){
 					strip.setPixelColor(q, LOWWHITE);
 				} else {
-					strip.setPixelColor(q, strip.ColorHSV(midiBg_Hue, midiBg_Sat, midiBg_Brightness));
+					strip.setPixelColor(q, strip.ColorHSV(colorConfig.midiBg_Hue, colorConfig.midiBg_Sat, colorConfig.midiBg_Brightness));
 				}
 			}
 		}
@@ -116,13 +120,13 @@ void OmxLeds::drawMidiLeds() {
 		if (!sysSettings.screenSaverMode){
 			// clear not held leds
 			for (int q = 1; q < LED_COUNT; q++){				
-				if (midiKeyState[q] == -1){
-					if (midiBg_Hue == 0){
+				if (midiSettings.midiKeyState[q] == -1){
+					if (colorConfig.midiBg_Hue == 0){
 						strip.setPixelColor(q, LEDOFF);
-					} else if (midiBg_Hue == 32){
+					} else if (colorConfig.midiBg_Hue == 32){
 						strip.setPixelColor(q, LOWWHITE);
 					} else {
-						strip.setPixelColor(q, strip.ColorHSV(midiBg_Hue, midiBg_Sat, midiBg_Brightness));
+						strip.setPixelColor(q, strip.ColorHSV(colorConfig.midiBg_Hue, colorConfig.midiBg_Sat, colorConfig.midiBg_Brightness));
 					}
 				}
 			}

--- a/OMX-27-firmware/omx_leds.cpp
+++ b/OMX-27-firmware/omx_leds.cpp
@@ -29,7 +29,7 @@ void OmxLeds::initSetup()
     delay(100);
 }
 
-void OmxLeds::updateLeds()
+void OmxLeds::updateBlinkStates()
 {
     blinkInterval = clockConfig.step_delay * 2;
     unsigned long slowBlinkInterval = blinkInterval * 2;
@@ -47,7 +47,7 @@ void OmxLeds::updateLeds()
 }
 
 void OmxLeds::drawMidiLeds() {
-    updateLeds();
+    updateBlinkStates();
 	// blinkInterval = clockConfig.step_delay*2;
 
 	// if (blink_msec >= blinkInterval){

--- a/OMX-27-firmware/omx_leds.cpp
+++ b/OMX-27-firmware/omx_leds.cpp
@@ -5,6 +5,27 @@
 //     Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 //  }
 
+void OmxLeds::initSetup()
+{
+    strip.begin();                       // INITIALIZE NeoPixel strip object (REQUIRED)
+    strip.show();                        // Turn OFF all pixels ASAP
+    strip.setBrightness(LED_BRIGHTNESS); // Set BRIGHTNESS to about 1/5 (max = 255)
+    for (int i = 0; i < LED_COUNT; i++)
+    { // For each pixel...
+        strip.setPixelColor(i, HALFWHITE);
+        strip.show(); // Send the updated pixel colors to the hardware.
+        delay(5);     // Pause before next pass through loop
+    }
+    rainbow(5); // rainbow startup pattern
+    delay(500);
+
+    // clear LEDs
+    strip.fill(0, 0, LED_COUNT);
+    strip.show();
+
+    delay(100);
+}
+
 void OmxLeds::updateLeds()
 {
     blinkInterval = clockConfig.step_delay * 2;
@@ -22,6 +43,94 @@ void OmxLeds::updateLeds()
     }
 }
 
+void OmxLeds::drawMidiLeds() {
+	blinkInterval = step_delay*2;
+
+	if (blink_msec >= blinkInterval){
+		blinkState = !blinkState;
+		blink_msec = 0;
+	}
+
+	if (midiSettings.midiAUX){
+		// Blink left/right keys for octave select indicators.
+		auto color1 = blinkState ? LIME : LEDOFF;
+		auto color2 = blinkState ? MAGENTA : LEDOFF;
+		auto color3 = blinkState ? ORANGE : LEDOFF;
+		auto color4 = blinkState ? RBLUE : LEDOFF;
+
+		for (int q = 1; q < LED_COUNT; q++){				
+			if (midiKeyState[q] == -1){
+				if (midiBg_Hue == 0){
+					strip.setPixelColor(q, LEDOFF);
+				} else if (midiBg_Hue == 32){
+					strip.setPixelColor(q, LOWWHITE);
+				} else {
+					strip.setPixelColor(q, strip.ColorHSV(midiBg_Hue, midiBg_Sat, midiBg_Brightness));
+				}
+			}
+		}
+		strip.setPixelColor(0, RED);
+		strip.setPixelColor(1, color1);
+		strip.setPixelColor(2, color2);
+		strip.setPixelColor(11, color3);
+		strip.setPixelColor(12, color4);
+	// Macros
+	} else if (midiMacroConfig.m8AUX){
+		auto color5 = blinkState ? ORANGE : LEDOFF;
+		auto color6 = blinkState ? RED : LEDOFF;
+
+		strip.setPixelColor(0, BLUE);
+		strip.setPixelColor(1, ORANGE); // all mute
+		strip.setPixelColor(3, LIME); // MIXER
+		strip.setPixelColor(4, CYAN); // snap load
+		strip.setPixelColor(5, MAGENTA); // snap save
+
+		for(int m = 11; m < LED_COUNT-8; m++){
+			if (m8mutesolo[m-11]){
+				strip.setPixelColor(m, color5);
+			}else{
+				strip.setPixelColor(m, ORANGE);
+			}
+		}
+		
+		strip.setPixelColor(6, RED); // all solo
+		for(int m = 19; m < LED_COUNT; m++){
+			if (m8mutesolo[m-11]){
+				strip.setPixelColor(m, color6);
+			}else{
+				strip.setPixelColor(m, RED);
+			}
+		}
+		strip.setPixelColor(2, LEDOFF);
+		strip.setPixelColor(7, LEDOFF);
+		strip.setPixelColor(8, LEDOFF);
+
+		strip.setPixelColor(9, YELLOW); // WAVES
+		strip.setPixelColor(10, BLUE); // PLAY
+
+	} else {
+		// AUX key
+		strip.setPixelColor(0, LEDOFF);
+		
+		// Other keys
+		if (!sysSettings.screenSaverMode){
+			// clear not held leds
+			for (int q = 1; q < LED_COUNT; q++){				
+				if (midiKeyState[q] == -1){
+					if (midiBg_Hue == 0){
+						strip.setPixelColor(q, LEDOFF);
+					} else if (midiBg_Hue == 32){
+						strip.setPixelColor(q, LOWWHITE);
+					} else {
+						strip.setPixelColor(q, strip.ColorHSV(midiBg_Hue, midiBg_Sat, midiBg_Brightness));
+					}
+				}
+			}
+		}
+	}
+	dirtyPixels = true;
+}
+
 bool OmxLeds::getBlinkState()
 {
     return blinkState;
@@ -31,11 +140,13 @@ bool OmxLeds::getSlowBlinkState()
     return slowBlinkState;
 }
 
-void OmxLeds::setAllLEDS(int R, int G, int B) {
-	for(int i=0; i<LED_COUNT; i++) { // For each pixel...
-		strip.setPixelColor(i, strip.Color(R, G, B));
-	}
-	setDirty();
+void OmxLeds::setAllLEDS(int R, int G, int B)
+{
+    for (int i = 0; i < LED_COUNT; i++)
+    { // For each pixel...
+        strip.setPixelColor(i, strip.Color(R, G, B));
+    }
+    setDirty();
 }
 
 void OmxLeds::setDirty()
@@ -45,11 +156,38 @@ void OmxLeds::setDirty()
 
 void OmxLeds::showLeds()
 {
-	// are pixels dirty
+    // are pixels dirty
     if (dirtyPixels)
     {
         strip.show();
         dirtyPixels = false;
+    }
+}
+
+void OmxLeds::rainbow(int wait)
+{
+    // Hue of first pixel runs 5 complete loops through the color wheel.
+    // Color wheel has a range of 65536 but it's OK if we roll over, so
+    // just count from 0 to 5*65536. Adding 256 to firstPixelHue each time
+    // means we'll make 5*65536/256 = 1280 passes through this outer loop:
+    for (long firstPixelHue = 0; firstPixelHue < 1 * 65536; firstPixelHue += 256)
+    {
+        for (int i = 0; i < strip.numPixels(); i++)
+        { // For each pixel in strip...
+            // Offset pixel hue by an amount to make one full revolution of the
+            // color wheel (range of 65536) along the length of the strip
+            // (strip.numPixels() steps):
+            int pixelHue = firstPixelHue + (i * 65536L / strip.numPixels());
+
+            // strip.ColorHSV() can take 1 or 3 arguments: a hue (0 to 65535) or
+            // optionally add saturation and value (brightness) (each 0 to 255).
+            // Here we're using just the single-argument hue variant. The result
+            // is passed through strip.gamma32() to provide 'truer' colors
+            // before assigning to each pixel:
+            strip.setPixelColor(i, strip.gamma32(strip.ColorHSV(pixelHue)));
+        }
+        strip.show(); // Update strip with new contents
+        delay(wait);  // Pause for a moment
     }
 }
 
@@ -83,7 +221,7 @@ void OmxLeds::colorWipe(byte red, byte green, byte blue, int SpeedDelay)
 
 // Theatre-style crawling lights with rainbow effect
 void OmxLeds::theaterChaseRainbow(uint8_t wait)
-{ 
+{
     for (int j = 0; j < 256; j++)
     { // cycle all 256 colors in the wheel
         for (int q = 0; q < 3; q++)

--- a/OMX-27-firmware/omx_leds.cpp
+++ b/OMX-27-firmware/omx_leds.cpp
@@ -1,0 +1,178 @@
+#include "omx_leds.h"
+#include "consts.h"
+
+//  OmxLeds::OmxLeds(){
+//     Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+//  }
+
+void OmxLeds::updateLeds()
+{
+    blinkInterval = clockConfig.step_delay * 2;
+    unsigned long slowBlinkInterval = blinkInterval * 2;
+
+    if (blink_msec >= blinkInterval)
+    {
+        blinkState = !blinkState;
+        blink_msec = 0;
+    }
+    if (slow_blink_msec >= slowBlinkInterval)
+    {
+        slowBlinkState = !slowBlinkState;
+        slow_blink_msec = 0;
+    }
+}
+
+bool OmxLeds::getBlinkState()
+{
+    return blinkState;
+}
+bool OmxLeds::getSlowBlinkState()
+{
+    return slowBlinkState;
+}
+
+void OmxLeds::setAllLEDS(int R, int G, int B) {
+	for(int i=0; i<LED_COUNT; i++) { // For each pixel...
+		strip.setPixelColor(i, strip.Color(R, G, B));
+	}
+	setDirty();
+}
+
+void OmxLeds::setDirty()
+{
+    dirtyPixels = true;
+}
+
+void OmxLeds::showLeds()
+{
+	// are pixels dirty
+    if (dirtyPixels)
+    {
+        strip.show();
+        dirtyPixels = false;
+    }
+}
+
+// Input a value 0 to 255 to get a color value.
+// The colours are a transition r - g - b - back to r.
+uint32_t OmxLeds::Wheel(byte WheelPos)
+{
+    WheelPos = 255 - WheelPos;
+    if (WheelPos < 85)
+    {
+        return strip.Color(255 - WheelPos * 3, 0, WheelPos * 3);
+    }
+    if (WheelPos < 170)
+    {
+        WheelPos -= 85;
+        return strip.Color(0, WheelPos * 3, 255 - WheelPos * 3);
+    }
+    WheelPos -= 170;
+    return strip.Color(WheelPos * 3, 255 - WheelPos * 3, 0);
+}
+
+void OmxLeds::colorWipe(byte red, byte green, byte blue, int SpeedDelay)
+{
+    for (uint16_t i = 0; i < strip.numPixels(); i++)
+    {
+        strip.setPixelColor(i, strip.Color(red, green, blue));
+        strip.show();
+        delay(SpeedDelay);
+    }
+}
+
+// Theatre-style crawling lights with rainbow effect
+void OmxLeds::theaterChaseRainbow(uint8_t wait)
+{ 
+    for (int j = 0; j < 256; j++)
+    { // cycle all 256 colors in the wheel
+        for (int q = 0; q < 3; q++)
+        {
+            for (uint16_t i = 0; i < strip.numPixels(); i = i + 3)
+            {
+                strip.setPixelColor(i + q, Wheel((i + j) % 255)); // turn every third pixel on
+            }
+            strip.show();
+            delay(wait);
+            for (uint16_t i = 0; i < strip.numPixels(); i = i + 3)
+            {
+                strip.setPixelColor(i + q, 0); // turn every third pixel off
+            }
+        }
+    }
+}
+
+void OmxLeds::CylonBounce(byte red, byte green, byte blue, int EyeSize, int SpeedDelay, int ReturnDelay, int start, int end)
+{
+    for (int i = start; i < end - EyeSize - 2; i++)
+    {
+        setAllLEDS(0, 0, 0);
+        strip.setPixelColor(i, strip.Color(red / 10, green / 10, blue / 10));
+        for (int j = 1; j <= EyeSize; j++)
+        {
+            strip.setPixelColor(i + j, strip.Color(red, green, blue));
+        }
+        strip.setPixelColor(i + EyeSize + 1, strip.Color(red / 10, green / 10, blue / 10));
+        strip.show();
+        delay(SpeedDelay);
+    }
+    delay(ReturnDelay);
+    for (int i = end - EyeSize - 2; i > start; i--)
+    {
+        setAllLEDS(0, 0, 0);
+        strip.setPixelColor(i, strip.Color(red / 10, green / 10, blue / 10));
+        for (int j = 1; j <= EyeSize; j++)
+        {
+            strip.setPixelColor(i + j, strip.Color(red, green, blue));
+        }
+        strip.setPixelColor(i + EyeSize + 1, strip.Color(red / 10, green / 10, blue / 10));
+        strip.show();
+        delay(SpeedDelay);
+    }
+    delay(ReturnDelay);
+}
+
+void OmxLeds::RolandFill(byte red, byte green, byte blue, int start, int end, int SpeedDelay)
+{
+    for (uint16_t j = end; j > start; j--)
+    {
+        for (uint16_t i = start; i < end; i++)
+        {
+            strip.setPixelColor(i, strip.Color(red, green, blue));
+            strip.show();
+            if (i < j)
+            {
+                strip.setPixelColor(i, 0);
+            }
+            if (!sysSettings.screenSaverMode)
+            {
+                return;
+            }
+        }
+        strip.setPixelColor(j, strip.Color(red, green, blue));
+        strip.show();
+    }
+    for (uint16_t j = end; j > start - 1; j--)
+    {
+        for (uint16_t i = start; i < end + 1; i++)
+        {
+            strip.setPixelColor(i, strip.Color(red, green, blue));
+            strip.show();
+            if (i > j)
+            {
+                strip.setPixelColor(i, 0);
+            }
+            if (!sysSettings.screenSaverMode)
+            {
+                return;
+            }
+        }
+        if (j != start)
+        {
+            strip.setPixelColor(j, strip.Color(red, green, blue));
+        }
+        strip.show();
+    }
+}
+
+OmxLeds omxLeds;

--- a/OMX-27-firmware/omx_leds.h
+++ b/OMX-27-firmware/omx_leds.h
@@ -13,6 +13,8 @@ public:
 
     OmxLeds(){};
 
+    void initSetup();
+
     void updateLeds();
 
     // clears dirty, transmits pixel data if dirty.
@@ -26,6 +28,9 @@ public:
     void setAllLEDS(int R, int G, int B);
 
     void setDirty();
+
+    // Rainbow cycle along whole strip. Pass delay time (in ms) between frames.
+    void rainbow(int wait);
 
     // #### COLOR FUNCTIONS
     // Input a value 0 to 255 to get a color value.
@@ -46,9 +51,6 @@ private:
 
     elapsedMillis blink_msec = 0;
     elapsedMillis slow_blink_msec = 0;
-
-    elapsedMillis dirtyDisplayTimer = 0;
-    unsigned long displayRefreshRate = 60;
 };
 
 extern OmxLeds omxLeds;

--- a/OMX-27-firmware/omx_leds.h
+++ b/OMX-27-firmware/omx_leds.h
@@ -1,0 +1,54 @@
+#pragma once
+#include "config.h"
+
+#include <Adafruit_NeoPixel.h>
+
+// Declare NeoPixel strip object
+Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+
+class OmxLeds
+{
+public:
+    // OmxLeds() : strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800){};
+
+    OmxLeds(){};
+
+    void updateLeds();
+
+    // clears dirty, transmits pixel data if dirty.
+    void showLeds();
+
+    bool getBlinkState();
+    bool getSlowBlinkState();
+
+    // void setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
+
+    void setAllLEDS(int R, int G, int B);
+
+    void setDirty();
+
+    // #### COLOR FUNCTIONS
+    // Input a value 0 to 255 to get a color value.
+    // The colours are a transition r - g - b - back to r.
+    uint32_t Wheel(byte WheelPos);
+    void colorWipe(byte red, byte green, byte blue, int SpeedDelay);
+    // Theatre-style crawling lights with rainbow effect
+    void theaterChaseRainbow(uint8_t wait);
+    void CylonBounce(byte red, byte green, byte blue, int EyeSize, int SpeedDelay, int ReturnDelay, int start, int end);
+    void RolandFill(byte red, byte green, byte blue, int start, int end, int SpeedDelay);
+
+private:
+    unsigned long blinkInterval = clockConfig.clockbpm * 2;
+    bool blinkState = false;
+    bool slowBlinkState = false;
+
+    bool dirtyPixels = false;
+
+    elapsedMillis blink_msec = 0;
+    elapsedMillis slow_blink_msec = 0;
+
+    elapsedMillis dirtyDisplayTimer = 0;
+    unsigned long displayRefreshRate = 60;
+};
+
+extern OmxLeds omxLeds;

--- a/OMX-27-firmware/omx_leds.h
+++ b/OMX-27-firmware/omx_leds.h
@@ -4,7 +4,7 @@
 #include <Adafruit_NeoPixel.h>
 
 // Declare NeoPixel strip object
-Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+extern Adafruit_NeoPixel strip;
 
 class OmxLeds
 {

--- a/OMX-27-firmware/omx_leds.h
+++ b/OMX-27-firmware/omx_leds.h
@@ -17,6 +17,8 @@ public:
 
     void updateLeds();
 
+    void drawMidiLeds();
+
     // clears dirty, transmits pixel data if dirty.
     void showLeds();
 

--- a/OMX-27-firmware/omx_leds.h
+++ b/OMX-27-firmware/omx_leds.h
@@ -15,7 +15,7 @@ public:
 
     void initSetup();
 
-    void updateLeds();
+    void updateBlinkStates();
 
     void drawMidiLeds();
 

--- a/OMX-27-firmware/omx_midi_macros.h
+++ b/OMX-27-firmware/omx_midi_macros.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};

--- a/OMX-27-firmware/omx_midi_macros.h
+++ b/OMX-27-firmware/omx_midi_macros.h
@@ -1,3 +1,0 @@
-#pragma once
-
-bool m8mutesolo[] = {false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false};

--- a/OMX-27-firmware/omx_mode_interface.h
+++ b/OMX-27-firmware/omx_mode_interface.h
@@ -8,9 +8,12 @@ public:
     OmxModeInterface() {}
     virtual ~OmxModeInterface() {}
 
-    virtual void InitSetup() {}
+    virtual void InitSetup() {} // Called once when mode is created
+
+    virtual void onModeActivated() {} // Called whenever entering mode
 
     virtual void OnPotChanged(int potIndex, int potValue) = 0;
+    virtual void loopUpdate() {}
     virtual void updateLEDs() = 0;
     virtual void onEncoderChanged(Encoder::Update enc) = 0;
     virtual void onEncoderButtonDown() = 0;

--- a/OMX-27-firmware/omx_mode_interface.h
+++ b/OMX-27-firmware/omx_mode_interface.h
@@ -12,7 +12,7 @@ public:
 
     virtual void onModeActivated() {} // Called whenever entering mode
 
-    virtual void OnPotChanged(int potIndex, int potValue) = 0;
+    virtual void onPotChanged(int potIndex, int potValue) = 0;
     virtual void loopUpdate() {}
     virtual void updateLEDs() = 0;
     virtual void onEncoderChanged(Encoder::Update enc) = 0;

--- a/OMX-27-firmware/omx_mode_interface.h
+++ b/OMX-27-firmware/omx_mode_interface.h
@@ -1,10 +1,26 @@
 #pragma once
+#include "ClearUI_Input.h"
+#include "omx_keypad.h"
 
 class OmxModeInterface
 {
 public:
-    OmxModeInterface(){}
-    virtual ~OmxModeInterface(){}
-    virtual void method1() = 0;    
-    virtual void method2() = 0;
+    OmxModeInterface() {}
+    virtual ~OmxModeInterface() {}
+
+    virtual void OnPotChanged(int potIndex, int potValue) = 0;
+    virtual void updateLEDs() = 0;
+    virtual void onEncoderChanged(Encoder::Update enc) = 0;
+    virtual void onEncoderButtonDown() = 0;
+    virtual void onEncoderButtonUp() {};
+    virtual void onEncoderButtonUpLong() {};
+
+    virtual bool shouldBlockEncEdit() { return false; } // return true if should block encoder mode switch / hold down encoder
+    virtual void onEncoderButtonDownLong() = 0; // Will only get called if shouldBlockEncEdit() returns true
+
+    virtual void onKeyUpdate(OMXKeypadEvent e) = 0;
+
+    virtual void onKeyHeldUpdate(OMXKeypadEvent e) {};
+
+    virtual void onDisplayUpdate() {};
 };

--- a/OMX-27-firmware/omx_mode_interface.h
+++ b/OMX-27-firmware/omx_mode_interface.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class OmxModeInterface
+{
+public:
+    OmxModeInterface(){}
+    virtual ~OmxModeInterface(){}
+    virtual void method1() = 0;    
+    virtual void method2() = 0;
+};

--- a/OMX-27-firmware/omx_mode_interface.h
+++ b/OMX-27-firmware/omx_mode_interface.h
@@ -8,6 +8,8 @@ public:
     OmxModeInterface() {}
     virtual ~OmxModeInterface() {}
 
+    virtual void InitSetup() {}
+
     virtual void OnPotChanged(int potIndex, int potValue) = 0;
     virtual void updateLEDs() = 0;
     virtual void onEncoderChanged(Encoder::Update enc) = 0;
@@ -23,4 +25,10 @@ public:
     virtual void onKeyHeldUpdate(OMXKeypadEvent e) {};
 
     virtual void onDisplayUpdate() {};
+
+    // #### Inbound MIDI callbacks
+    virtual void inMidiNoteOn(byte channel, byte note, byte velocity) {}
+    virtual void inMidiNoteOff(byte channel, byte note, byte velocity) {}
+    virtual void inMidiControlChange(byte channel, byte control,  byte value) {}
+
 };

--- a/OMX-27-firmware/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.cpp
@@ -1,0 +1,3 @@
+#include "omx_mode_midi_keyboard.h"
+
+

--- a/OMX-27-firmware/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.cpp
@@ -1,3 +1,428 @@
 #include "omx_mode_midi_keyboard.h"
+#include "config.h"
+#include "omx_util.h"
+#include "omx_disp.h"
+#include "omx_leds.h"
 
+void OmxModeMidiKeyboard::OnPotChanged(int potIndex, int potValue)
+{
+    if (midiMacroConfig.midiMacro)
+    {
+        omxUtil.sendPots(potIndex, midiMacroConfig.midiMacroChan);
+    }
+    else
+    {
+        omxUtil.sendPots(potIndex, sysSettings.midiChannel);
+    }
 
+    omxDisp.setDirty();
+}
+
+void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
+{
+    if (organelleMotherMode)
+    {
+        // CHANGE PAGE
+        if (miparam == 0)
+        {
+            if (u.dir() < 0)
+            { // if turn ccw
+                MM::sendControlChange(CC_OM2, 0, sysSettings.midiChannel);
+            }
+            else if (u.dir() > 0)
+            { // if turn cw
+                MM::sendControlChange(CC_OM2, 127, sysSettings.midiChannel);
+            }
+        }
+        dirtyDisplay = true;
+    }
+
+    if (midiAUX)
+    {
+        // change MIDI Background Color
+        // midiBg_Hue = constrain(midiBg_Hue + (amt * 32), 0, 65534); // 65535
+        break;
+    }
+    // CHANGE PAGE
+    if (miparam == 0 || miparam == 5 || miparam == 10)
+    {
+        mmpage = constrain(mmpage + amt, 0, 2);
+        miparam = mmpage * NUM_DISP_PARAMS;
+    }
+    // PAGE ONE
+    if (miparam == 2)
+    {
+        int newchan = constrain(sysSettings.midiChannel + amt, 1, 16);
+        if (newchan != sysSettings.midiChannel)
+        {
+            sysSettings.midiChannel = newchan;
+        }
+    }
+    else if (miparam == 1)
+    {
+        // set octave
+        newoctave = constrain(octave + amt, -5, 4);
+        if (newoctave != octave)
+        {
+            octave = newoctave;
+        }
+    }
+    // PAGE TWO
+    if (miparam == 6)
+    {
+        int newrrchan = constrain(midiRRChannelCount + amt, 1, 16);
+        if (newrrchan != midiRRChannelCount)
+        {
+            midiRRChannelCount = newrrchan;
+            if (midiRRChannelCount == 1)
+            {
+                midiRoundRobin = false;
+            }
+            else
+            {
+                midiRoundRobin = true;
+            }
+        }
+    }
+    else if (miparam == 7)
+    {
+        midiRRChannelOffset = constrain(midiRRChannelOffset + amt, 0, 15);
+    }
+    else if (miparam == 8)
+    {
+        currpgm = constrain(currpgm + amt, 0, 127);
+
+        if (midiRoundRobin)
+        {
+            for (int q = midiRRChannelOffset + 1; q < midiRRChannelOffset + midiRRChannelCount + 1; q++)
+            {
+                MM::sendProgramChange(currpgm, q);
+            }
+        }
+        else
+        {
+            MM::sendProgramChange(currpgm, sysSettings.midiChannel);
+        }
+    }
+    else if (miparam == 9)
+    {
+        currbank = constrain(currbank + amt, 0, 127);
+        // Bank Select is 2 mesages
+        MM::sendControlChange(0, 0, sysSettings.midiChannel);
+        MM::sendControlChange(32, currbank, sysSettings.midiChannel);
+        MM::sendProgramChange(currpgm, sysSettings.midiChannel);
+    }
+    // PAGE THREE
+    if (miparam == 11)
+    {
+        potbank = constrain(potbank + amt, 0, NUM_CC_BANKS - 1);
+    }
+    if (miparam == 12)
+    {
+        midiSoftThru = constrain(midiSoftThru + amt, 0, 1);
+    }
+    if (miparam == 13)
+    {
+        midiMacro = constrain(midiMacro + amt, 0, nummacromodes);
+    }
+    if (miparam == 14)
+    {
+        midiMacroChan = constrain(midiMacroChan + amt, 1, 16);
+    }
+
+    dirtyDisplay = true;
+}
+
+void OmxModeMidiKeyboard::onEncoderButtonDown()
+{
+    if (organelleMotherMode)
+    {
+        miparam = (miparam + 1) % NUM_DISP_PARAMS;
+        // MM::sendControlChange(CC_OM1,100,sysSettings.midiChannel);
+    }
+    else
+    {
+        // switch midi oct/chan selection
+        miparam = (miparam + 1) % 15;
+        mmpage = miparam / NUM_DISP_PARAMS;
+    }
+}
+
+void OmxModeMidiKeyboard::onEncoderButtonUp()
+{
+    if (organelleMotherMode)
+    {
+        //				MM::sendControlChange(CC_OM1,0,sysSettings.midiChannel);
+    }
+}
+
+void OmxModeMidiKeyboard::onEncoderButtonDownLong()
+{
+}
+
+void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
+{
+    int thisKey = e.key();
+    int keyPos = thisKey - 11;
+
+    // ### KEY PRESS EVENTS
+    if (midiSettings.midiMacro)
+    {
+        if (e.clicks() == 2 && thisKey == 0)
+        {
+            m8AUX = !m8AUX;
+            if (!m8AUX)
+            {
+                for (int m = 1; m < LED_COUNT; m++)
+                {
+                    strip.setPixelColor(m, LEDOFF);
+                }
+            }
+        }
+        if (m8AUX)
+        {
+            if (!e.held())
+            {
+                if (e.down() && (thisKey > 10 && thisKey < 27))
+                {
+                    // Mutes / Solos
+                    m8mutesolo[keyPos] = !m8mutesolo[keyPos];
+                    int mutePos = keyPos + 12;
+                    if (m8mutesolo[keyPos])
+                    {
+                        MM::sendNoteOn(mutePos, 1, midiMacroChan);
+                    }
+                    else
+                    {
+                        MM::sendNoteOff(mutePos, 0, midiMacroChan);
+                    }
+                    break;
+                }
+                else if (e.down() && (thisKey == 1))
+                {
+                    // release all mutes
+                    for (int z = 0; z < 8; z++)
+                    {
+                        int mutePos = z + 12;
+                        if (m8mutesolo[z])
+                        {
+                            m8mutesolo[z] = false;
+                            MM::sendNoteOff(mutePos, 0, midiMacroChan);
+                        }
+                    }
+                    break;
+                }
+                else if (e.down() && (thisKey == 2))
+                {
+                    // ?
+                    break;
+                }
+                else if (e.down() && (thisKey == 3))
+                {
+                    // return to mixer
+                    // hold shift 4 left 1 down, release shift
+                    MM::sendNoteOn(1, 1, midiMacroChan); // Shift
+                    delay(40);
+                    MM::sendNoteOn(6, 1, midiMacroChan); // Up
+                    delay(20);
+                    MM::sendNoteOff(6, 0, midiMacroChan);
+                    delay(40);
+                    MM::sendNoteOn(4, 1, midiMacroChan); // Left
+                    delay(20);
+                    MM::sendNoteOff(4, 0, midiMacroChan);
+                    delay(40);
+                    MM::sendNoteOn(4, 1, midiMacroChan); // Left
+                    delay(20);
+                    MM::sendNoteOff(4, 0, midiMacroChan);
+                    delay(40);
+                    MM::sendNoteOn(4, 1, midiMacroChan); // Left
+                    delay(20);
+                    MM::sendNoteOff(4, 0, midiMacroChan);
+                    delay(40);
+                    MM::sendNoteOn(4, 1, midiMacroChan); // Left
+                    delay(20);
+                    MM::sendNoteOff(4, 0, midiMacroChan);
+                    delay(40);
+                    MM::sendNoteOn(7, 1, midiMacroChan); // Down
+                    delay(20);
+                    MM::sendNoteOff(7, 0, midiMacroChan);
+                    MM::sendNoteOff(1, 0, midiMacroChan);
+
+                    break;
+                }
+                else if (e.down() && (thisKey == 4))
+                {
+                    // snap save
+                    MM::sendNoteOn(1, 1, midiMacroChan); // Shift
+                    delay(40);
+                    MM::sendNoteOn(3, 1, midiMacroChan); // Option
+                    delay(40);
+                    MM::sendNoteOff(3, 0, midiMacroChan);
+                    MM::sendNoteOff(1, 0, midiMacroChan);
+
+                    break;
+                }
+                else if (e.down() && (thisKey == 5))
+                {
+                    // snap load
+                    MM::sendNoteOn(1, 1, midiMacroChan); // Shift
+                    delay(40);
+                    MM::sendNoteOn(2, 1, midiMacroChan); // Edit
+                    delay(40);
+                    MM::sendNoteOff(2, 0, midiMacroChan);
+                    MM::sendNoteOff(1, 0, midiMacroChan);
+
+                    // then reset mutes/solos
+                    for (int z = 0; z < 16; z++)
+                    {
+                        if (m8mutesolo[z])
+                        {
+                            m8mutesolo[z] = false;
+                        }
+                    }
+
+                    break;
+                }
+                else if (e.down() && (thisKey == 6))
+                {
+                    // release all solos
+                    for (int z = 8; z < 16; z++)
+                    {
+                        int mutePos = z + 12;
+                        if (m8mutesolo[z])
+                        {
+                            m8mutesolo[z] = false;
+                            MM::sendNoteOff(mutePos, 0, midiMacroChan);
+                        }
+                    }
+                    break;
+                }
+                else if (e.down() && (thisKey == 7))
+                {
+                    // ??
+                    break;
+                }
+                else if (e.down() && (thisKey == 8))
+                {
+                    // ??
+                    break;
+                }
+                else if (e.down() && (thisKey == 9))
+                {
+                    // waveform
+                    MM::sendNoteOn(6, 1, midiMacroChan); // Up
+                    MM::sendNoteOn(7, 1, midiMacroChan); // Down
+                    MM::sendNoteOn(5, 1, midiMacroChan); // Right
+                    MM::sendNoteOn(4, 1, midiMacroChan); // Left
+                    delay(40);
+
+                    MM::sendNoteOff(6, 0, midiMacroChan); // Up
+                    MM::sendNoteOff(7, 0, midiMacroChan); // Down
+                    MM::sendNoteOff(5, 0, midiMacroChan); // Right
+                    MM::sendNoteOff(4, 0, midiMacroChan); // Left
+
+                    break;
+                }
+                else if (e.down() && (thisKey == 10))
+                {
+                    // play
+                    MM::sendNoteOn(0, 1, midiMacroChan); // Play
+                    delay(40);
+                    MM::sendNoteOff(0, 0, midiMacroChan); // Play
+
+                    //								MM::sendNoteOn(1, 1, midiMacroChan); // Shift
+                    //								MM::sendNoteOn(3, 1, midiMacroChan); // Option
+                    //								MM::sendNoteOn(2, 1, midiMacroChan); // Edit
+                    //								MM::sendNoteOn(6, 1, midiMacroChan); // Up
+                    //								MM::sendNoteOn(7, 1, midiMacroChan); // Down
+                    //								MM::sendNoteOn(4, 1, midiMacroChan); // Left
+                    //								MM::sendNoteOn(5, 1, midiMacroChan); // Right
+                    break;
+                }
+            }
+        }
+    }
+
+    // REGULAR KEY PRESSES
+    if (!e.held())
+    { // IGNORE LONG PRESS EVENTS
+        if (e.down() && thisKey != 0)
+        {
+            // Serial.println(" pressed");
+            if (thisKey == 11 || thisKey == 12 || thisKey == 1 || thisKey == 2)
+            {
+                if (midiAUX)
+                {
+                    if (thisKey == 11 || thisKey == 12)
+                    {
+                        int amt = thisKey == 11 ? -1 : 1;
+                        newoctave = constrain(octave + amt, -5, 4);
+                        if (newoctave != octave)
+                        {
+                            octave = newoctave;
+                        }
+                    }
+                    else if (thisKey == 1 || thisKey == 2)
+                    {
+                        int chng = thisKey == 1 ? -1 : 1;
+                        miparam = constrain((miparam + chng) % 15, 0, 14);
+                        mmpage = miparam / NUM_DISP_PARAMS;
+                    }
+                }
+                else
+                {
+                    midiNoteOn(thisKey, defaultVelocity, sysSettings.midiChannel);
+                }
+            }
+            else
+            {
+                midiNoteOn(thisKey, defaultVelocity, sysSettings.midiChannel);
+            }
+        }
+        else if (!e.down() && thisKey != 0)
+        {
+            midiNoteOff(thisKey, sysSettings.midiChannel);
+        }
+    }
+    //				Serial.println(e.clicks());
+
+    // AUX KEY
+    if (e.down() && thisKey == 0)
+    {
+        // Hard coded Organelle stuff
+        //					MM::sendControlChange(CC_AUX, 100, sysSettings.midiChannel);
+
+        if (!m8AUX)
+        {
+            midiAUX = true;
+        }
+
+        //					if (midiAUX) {
+        //						// STOP CLOCK
+        //						Serial.println("stop clock");
+        //					} else {
+        //						// START CLOCK
+        //						Serial.println("start clock");
+        //					}
+        //					midiAUX = !midiAUX;
+    }
+    else if (!e.down() && thisKey == 0)
+    {
+        // Hard coded Organelle stuff
+        //					MM::sendControlChange(CC_AUX, 0, sysSettings.midiChannel);
+        if (midiAUX)
+        {
+            midiAUX = false;
+        }
+        // turn off leds
+        strip.setPixelColor(0, LEDOFF);
+        strip.setPixelColor(1, LEDOFF);
+        strip.setPixelColor(2, LEDOFF);
+        strip.setPixelColor(11, LEDOFF);
+        strip.setPixelColor(12, LEDOFF);
+    }
+}
+
+void OmxModeMidiKeyboard::updateLEDs()
+{
+}

--- a/OMX-27-firmware/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.cpp
@@ -6,6 +6,19 @@
 #include "omx_leds.h"
 #include "MM.h"
 
+void OmxModeMidiKeyboard::InitSetup()
+{
+    initSetup = true;
+}
+
+void OmxModeMidiKeyboard::onModeActivated()
+{
+    // auto init when activated
+    if(!initSetup){
+        InitSetup();
+    }
+}
+
 void OmxModeMidiKeyboard::OnPotChanged(int potIndex, int potValue)
 {
     if (midiMacroConfig.midiMacro)
@@ -25,7 +38,7 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
     if (organelleMotherMode)
     {
         // CHANGE PAGE
-        if (miparam == 0)
+        if (midiPageParams.miparam  == 0)
         {
             if (enc.dir() < 0)
             { // if turn ccw
@@ -50,13 +63,13 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
     auto amt = enc.accel(5); // where 5 is the acceleration factor if you want it, 0 if you don't)
 
     // CHANGE PAGE
-    if (miparam == 0 || miparam == 5 || miparam == 10)
+    if (midiPageParams.miparam  == 0 || midiPageParams.miparam  == 5 || midiPageParams.miparam  == 10)
     {
-        mmpage = constrain(mmpage + amt, 0, 2);
-        miparam = mmpage * NUM_DISP_PARAMS;
+        midiPageParams.mmpage = constrain(midiPageParams.mmpage + amt, 0, 2);
+        midiPageParams.miparam  = midiPageParams.mmpage * NUM_DISP_PARAMS;
     }
     // PAGE ONE
-    if (miparam == 2)
+    if (midiPageParams.miparam  == 2)
     {
         int newchan = constrain(sysSettings.midiChannel + amt, 1, 16);
         if (newchan != sysSettings.midiChannel)
@@ -64,7 +77,7 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
             sysSettings.midiChannel = newchan;
         }
     }
-    else if (miparam == 1)
+    else if (midiPageParams.miparam  == 1)
     {
         // set octave
         midiSettings.newoctave = constrain(midiSettings.octave + amt, -5, 4);
@@ -74,7 +87,7 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
         }
     }
     // PAGE TWO
-    if (miparam == 6)
+    if (midiPageParams.miparam  == 6)
     {
         int newrrchan = constrain(midiSettings.midiRRChannelCount + amt, 1, 16);
         if (newrrchan != midiSettings.midiRRChannelCount)
@@ -90,11 +103,11 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
             }
         }
     }
-    else if (miparam == 7)
+    else if (midiPageParams.miparam  == 7)
     {
         midiSettings.midiRRChannelOffset = constrain(midiSettings.midiRRChannelOffset + amt, 0, 15);
     }
-    else if (miparam == 8)
+    else if (midiPageParams.miparam  == 8)
     {
         midiSettings.currpgm = constrain(midiSettings.currpgm + amt, 0, 127);
 
@@ -110,7 +123,7 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
             MM::sendProgramChange(midiSettings.currpgm, sysSettings.midiChannel);
         }
     }
-    else if (miparam == 9)
+    else if (midiPageParams.miparam  == 9)
     {
         midiSettings.currbank = constrain(midiSettings.currbank + amt, 0, 127);
         // Bank Select is 2 mesages
@@ -119,19 +132,19 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
         MM::sendProgramChange(midiSettings.currpgm, sysSettings.midiChannel);
     }
     // PAGE THREE
-    if (miparam == 11)
+    if (midiPageParams.miparam  == 11)
     {
         potSettings.potbank = constrain(potSettings.potbank + amt, 0, NUM_CC_BANKS - 1);
     }
-    if (miparam == 12)
+    if (midiPageParams.miparam  == 12)
     {
         midiSettings.midiSoftThru = constrain(midiSettings.midiSoftThru + amt, 0, 1);
     }
-    if (miparam == 13)
+    if (midiPageParams.miparam  == 13)
     {
         midiMacroConfig.midiMacro = constrain(midiMacroConfig.midiMacro + amt, 0, nummacromodes);
     }
-    if (miparam == 14)
+    if (midiPageParams.miparam  == 14)
     {
         midiMacroConfig.midiMacroChan = constrain(midiMacroConfig.midiMacroChan + amt, 1, 16);
     }
@@ -143,14 +156,14 @@ void OmxModeMidiKeyboard::onEncoderButtonDown()
 {
     if (organelleMotherMode)
     {
-        miparam = (miparam + 1) % NUM_DISP_PARAMS;
+        midiPageParams.miparam  = (midiPageParams.miparam  + 1) % NUM_DISP_PARAMS;
         // MM::sendControlChange(CC_OM1,100,sysSettings.midiChannel);
     }
     else
     {
         // switch midi oct/chan selection
-        miparam = (miparam + 1) % 15;
-        mmpage = miparam / NUM_DISP_PARAMS;
+        midiPageParams.miparam  = (midiPageParams.miparam  + 1) % 15;
+        midiPageParams.mmpage = midiPageParams.miparam  / NUM_DISP_PARAMS;
     }
 }
 
@@ -371,8 +384,8 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
                     else if (thisKey == 1 || thisKey == 2)
                     {
                         int chng = thisKey == 1 ? -1 : 1;
-                        miparam = constrain((miparam + chng) % 15, 0, 14);
-                        mmpage = miparam / NUM_DISP_PARAMS;
+                        midiPageParams.miparam  = constrain((midiPageParams.miparam  + chng) % 15, 0, 14);
+                        midiPageParams.mmpage = midiPageParams.miparam  / NUM_DISP_PARAMS;
                     }
                 }
                 else
@@ -442,8 +455,8 @@ void OmxModeMidiKeyboard::onDisplayUpdate()
     { // DISPLAY
         if (!encoderConfig.enc_edit)
         {
-            int pselected = miparam % NUM_DISP_PARAMS;
-            if (mmpage == 0) // SUBMODE_MIDI
+            int pselected = midiPageParams.miparam  % NUM_DISP_PARAMS;
+            if (midiPageParams.mmpage == 0) // SUBMODE_MIDI
             {
                 //			if (midiRoundRobin) {
                 //				displaychan = rrChannel;
@@ -460,7 +473,7 @@ void OmxModeMidiKeyboard::onDisplayUpdate()
 
                 omxDisp.dispGenericMode(pselected);
             }
-            else if (mmpage == 1) // SUBMODE_MIDI2
+            else if (midiPageParams.mmpage == 1) // SUBMODE_MIDI2
             {
                 omxDisp.legends[0] = "RR";
                 omxDisp.legends[1] = "RROF";
@@ -473,7 +486,7 @@ void OmxModeMidiKeyboard::onDisplayUpdate()
                 omxDisp.dispPage = 2;
                 omxDisp.dispGenericMode(pselected);
             }
-            else if (mmpage == 2) // SUBMODE_MIDI3
+            else if (midiPageParams.mmpage == 2) // SUBMODE_MIDI3
             {
                 omxDisp.legends[0] = "PBNK"; // Potentiometer Banks
                 omxDisp.legends[1] = "THRU"; // MIDI thru (usb to hardware)

--- a/OMX-27-firmware/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.cpp
@@ -1,5 +1,6 @@
 #include "omx_mode_midi_keyboard.h"
 #include "config.h"
+#include "colors.h"
 #include "omx_util.h"
 #include "omx_disp.h"
 #include "omx_leds.h"
@@ -425,4 +426,101 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 
 void OmxModeMidiKeyboard::updateLEDs()
 {
+}
+
+void OmxModeMidiKeyboard::onDisplayUpdate()
+{
+    // playingPattern = 0; 		// DEFAULT MIDI MODE TO THE FIRST PATTERN SLOT
+    midi_leds(); // SHOW LEDS
+    if (dirtyDisplay)
+    { // DISPLAY
+        if (!encoderConfig.enc_edit)
+        {
+            int pselected = miparam % NUM_DISP_PARAMS;
+            if (mmpage == 0)
+            {
+                dispGenericMode(SUBMODE_MIDI, pselected);
+            }
+            else if (mmpage == 1)
+            {
+                dispGenericMode(SUBMODE_MIDI2, pselected);
+            }
+            else if (mmpage == 2)
+            {
+                dispGenericMode(SUBMODE_MIDI3, pselected);
+            }
+        }
+    }
+}
+
+// incoming midi note on
+void OmxModeMidiKeyboard::inMidiNoteOn(byte channel, byte note, byte velocity)
+{
+    if(organelleMotherMode) return;
+
+    midiSettings.midiLastNote = note;
+    int whatoct = (note / 12);
+    int thisKey;
+    uint32_t keyColor = MIDINOTEON;
+
+    if ((whatoct % 2) == 0)
+    {
+        thisKey = note - (12 * whatoct);
+    }
+    else
+    {
+        thisKey = note - (12 * whatoct) + 12;
+    }
+    if (whatoct == 0)
+    { // ORANGE,YELLOW,GREEN,MAGENTA,CYAN,BLUE,LIME,LTPURPLE
+    }
+    else if (whatoct == 1)
+    {
+        keyColor = ORANGE;
+    }
+    else if (whatoct == 2)
+    {
+        keyColor = YELLOW;
+    }
+    else if (whatoct == 3)
+    {
+        keyColor = GREEN;
+    }
+    else if (whatoct == 4)
+    {
+        keyColor = MAGENTA;
+    }
+    else if (whatoct == 5)
+    {
+        keyColor = CYAN;
+    }
+    else if (whatoct == 6)
+    {
+        keyColor = LIME;
+    }
+    else if (whatoct == 7)
+    {
+        keyColor = CYAN;
+    }
+    strip.setPixelColor(midiKeyMap[thisKey], keyColor); //  Set pixel's color (in RAM)
+                                                        //	dirtyPixels = true;
+    strip.show();
+    omxDisp.setDirty();
+}
+
+void OmxModeMidiKeyboard::inMidiNoteOff(byte channel, byte note, byte velocity) {
+    if(organelleMotherMode) return;
+
+    int whatoct = (note / 12);
+		int thisKey;
+		if ( (whatoct % 2) == 0) {
+			thisKey = note - (12 * whatoct);
+		} else {
+			thisKey = note - (12 * whatoct) + 12;
+		}
+		strip.setPixelColor(midiKeyMap[thisKey], LEDOFF);         //  Set pixel's color (in RAM)
+	//	dirtyPixels = true;
+		strip.show();
+		omxDisp.setDirty();
+    
 }

--- a/OMX-27-firmware/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.cpp
@@ -19,7 +19,7 @@ void OmxModeMidiKeyboard::onModeActivated()
     }
 }
 
-void OmxModeMidiKeyboard::OnPotChanged(int potIndex, int potValue)
+void OmxModeMidiKeyboard::onPotChanged(int potIndex, int potValue)
 {
     if (midiMacroConfig.midiMacro)
     {

--- a/OMX-27-firmware/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.h
@@ -8,6 +8,19 @@ public:
     OmxModeMidiKeyboard() {}
     ~OmxModeMidiKeyboard() {}
 
+    void InitSetup() override;
+    void onModeActivated() override;
+
+    void setOrganelleMode()
+    {
+        organelleMotherMode = true;
+    }
+
+    void setMidiMode()
+    {
+        organelleMotherMode = false;
+    }
+
     void OnPotChanged(int potIndex, int potValue) override;
 
     void updateLEDs() override;
@@ -25,15 +38,13 @@ public:
     void inMidiNoteOn(byte channel, byte note, byte velocity) override;
     void inMidiNoteOff(byte channel, byte note, byte velocity) override;
 
-    void setOrganelleMode()
-    {
-        organelleMotherMode = true;
-    }
+    
 
 private:
+    bool initSetup = false;
     bool organelleMotherMode = false; // TODO make separate class for this
 
-    int miparam = 0; // midi params item counter
+    // int miparam = 0; // midi params item counter
 
-    int mmpage = 0;
+    // int mmpage = 0;
 };

--- a/OMX-27-firmware/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.h
@@ -21,7 +21,7 @@ public:
         organelleMotherMode = false;
     }
 
-    void OnPotChanged(int potIndex, int potValue) override;
+    void onPotChanged(int potIndex, int potValue) override;
 
     void updateLEDs() override;
 
@@ -37,14 +37,7 @@ public:
     void onDisplayUpdate() override;
     void inMidiNoteOn(byte channel, byte note, byte velocity) override;
     void inMidiNoteOff(byte channel, byte note, byte velocity) override;
-
-    
-
 private:
     bool initSetup = false;
     bool organelleMotherMode = false; // TODO make separate class for this
-
-    // int miparam = 0; // midi params item counter
-
-    // int mmpage = 0;
 };

--- a/OMX-27-firmware/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.h
@@ -5,8 +5,8 @@
 class OmxModeMidiKeyboard : public OmxModeInterface
 {
 public:
-    OmxModeMidiKeyboard(){}
-    ~OmxModeMidiKeyboard(){}
+    OmxModeMidiKeyboard() {}
+    ~OmxModeMidiKeyboard() {}
 
     void OnPotChanged(int potIndex, int potValue) override;
 
@@ -19,7 +19,16 @@ public:
     void onEncoderButtonDownLong() override;
 
     void onKeyUpdate(OMXKeypadEvent e) override;
-    void onKeyHeldUpdate(OMXKeypadEvent e) {};
+    void onKeyHeldUpdate(OMXKeypadEvent e){};
+
+    void onDisplayUpdate() override;
+    void inMidiNoteOn(byte channel, byte note, byte velocity) override;
+    void inMidiNoteOff(byte channel, byte note, byte velocity) override;
+
+    void setOrganelleMode()
+    {
+        organelleMotherMode = true;
+    }
 
 private:
     bool organelleMotherMode = false; // TODO make separate class for this

--- a/OMX-27-firmware/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.h
@@ -7,34 +7,20 @@ class OmxModeMidiKeyboard : public OmxModeInterface
 public:
     OmxModeMidiKeyboard(){}
     ~OmxModeMidiKeyboard(){}
-    void method1();
-    void method2();
+
+    void OnPotChanged(int potIndex, int potValue) override;
+
+    void updateLEDs() override;
+
+    void onEncoderChanged(Encoder::Update enc) override;
+    void onEncoderButtonDown() override;
+    void onEncoderButtonUp() override;
+
+    void onEncoderButtonDownLong() override;
+
+    void onKeyUpdate(OMXKeypadEvent e) override;
+    void onKeyHeldUpdate(OMXKeypadEvent e) {};
 
 private:
-    int myMember;
-
+    bool organelleMotherMode = false; // TODO make separate class for this
 };
-
-// Provide implementation for the first method
-void Concrete::method1()
-{
-    // Your implementation
-}
-
-// Provide implementation for the second method
-void Concrete::method2()
-{
-    // Your implementation
-}
-
-int main(void)
-{
-    Interface *f = new Concrete();
-
-    f->method1();
-    f->method2();
-
-    delete f;
-
-    return 0;
-}

--- a/OMX-27-firmware/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.h
@@ -32,4 +32,8 @@ public:
 
 private:
     bool organelleMotherMode = false; // TODO make separate class for this
+
+    int miparam = 0; // midi params item counter
+
+    int mmpage = 0;
 };

--- a/OMX-27-firmware/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/omx_mode_midi_keyboard.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "omx_mode_interface.h"
+
+class OmxModeMidiKeyboard : public OmxModeInterface
+{
+public:
+    OmxModeMidiKeyboard(){}
+    ~OmxModeMidiKeyboard(){}
+    void method1();
+    void method2();
+
+private:
+    int myMember;
+
+};
+
+// Provide implementation for the first method
+void Concrete::method1()
+{
+    // Your implementation
+}
+
+// Provide implementation for the second method
+void Concrete::method2()
+{
+    // Your implementation
+}
+
+int main(void)
+{
+    Interface *f = new Concrete();
+
+    f->method1();
+    f->method2();
+
+    delete f;
+
+    return 0;
+}

--- a/OMX-27-firmware/omx_mode_sequencer.cpp
+++ b/OMX-27-firmware/omx_mode_sequencer.cpp
@@ -1,0 +1,1143 @@
+#include "omx_mode_sequencer.h"
+#include "config.h"
+#include "colors.h"
+#include "omx_util.h"
+#include "omx_disp.h"
+#include "sequencer.h"
+#include "omx_leds.h"
+
+void OmxModeSequencer::OnPotChanged(int potIndex, int potValue)
+{
+    if (noteSelect && noteSelection)
+    { // note selection - do P-Locks
+        potSettings.potNum = potIndex;
+        potSettings.potCC = pots[potSettings.potbank][potIndex];
+        potSettings.potVal = potSettings.analogValues[potIndex];
+
+        if (potIndex < 4)
+        { // only store p-lock value for first 4 knobs
+            getSelectedStep()->params[potIndex] = potSettings.analogValues[potIndex];
+            omxUtil.sendPots(potIndex, sequencer.getPatternChannel(sequencer.playingPattern));
+        }
+        omxUtil.sendPots(potIndex, sequencer.getPatternChannel(sequencer.playingPattern));
+        omxDisp.setDirty();
+    }
+    else if (stepRecord)
+    {
+        potSettings.potNum = potIndex;
+        potSettings.potCC = pots[potSettings.potbank][potIndex];
+        potSettings.potVal = potSettings.analogValues[potIndex];
+
+        if (potIndex < 4)
+        { // only store p-lock value for first 4 knobs
+            sequencer.getCurrentPattern()->steps[sequencer.seqPos[sequencer.playingPattern]].params[potIndex] = potSettings.analogValues[potIndex];
+            omxUtil.sendPots(potIndex, sequencer.getPatternChannel(sequencer.playingPattern));
+        }
+        else if (potIndex == 4)
+        {
+            sequencer.getCurrentPattern()->steps[sequencer.seqPos[sequencer.playingPattern]].vel = potSettings.analogValues[potIndex]; // SET POT 5 to NOTE VELOCITY HERE
+        }
+        omxDisp.setDirty();
+    }
+    else if (!noteSelect || !stepRecord)
+    {
+        omxUtil.sendPots(potIndex, sequencer.getPatternChannel(sequencer.playingPattern));
+    }
+}
+
+void OmxModeSequencer::onEncoderChanged(Encoder::Update enc)
+{
+    if (!noteSelect && !patternParams && !stepRecord)
+    {
+        onEncoderChangedNorm(enc);
+    }
+    else
+    {
+        onEncoderChangedStep(enc);
+    }
+}
+
+void OmxModeSequencer::onEncoderChangedNorm(Encoder::Update enc)
+{
+    auto amt = enc.accel(5); // where 5 is the acceleration factor if you want it, 0 if you don't)
+
+    // CHANGE PAGE
+    if (sqparam == 0 || sqparam == 5)
+    {
+        sqpage = constrain(sqpage + amt, 0, 1);
+        sqparam = sqpage * NUM_DISP_PARAMS;
+    }
+
+    // PAGE ONE
+    if (sqparam == 1)
+    {
+        sequencer.playingPattern = constrain(sequencer.playingPattern + amt, 0, 7);
+        if (sequencer.getCurrentPattern()->solo)
+        {
+            setAllLEDS(0, 0, 0);
+        }
+    }
+    else if (sqparam == 2)
+    {                                                // SET TRANSPOSE
+        transposeSeq(sequencer.playingPattern, amt); //
+        int newtransp = constrain(transpose + amt, -64, 63);
+        transpose = newtransp;
+    }
+    else if (sqparam == 3)
+    {                                                                                          // SET SWING
+        int newswing = constrain(sequencer.getCurrentPattern()->swing + amt, 0, maxswing - 1); // -1 to deal with display values
+        swing = newswing;
+        sequencer.getCurrentPattern()->swing = newswing;
+        //	setGlobalSwing(newswing);
+    }
+    else if (sqparam == 4)
+    { // SET TEMPO
+        newtempo = constrain(clockbpm + amt, 40, 300);
+        if (newtempo != clockbpm)
+        {
+            // SET TEMPO HERE
+            clockbpm = newtempo;
+            resetClocks();
+        }
+    }
+
+    // PAGE TWO
+    if (sqparam == 6)
+    { //  MIDI SOLO
+        //						playingPattern = constrain(playingPattern + amt, 0, 7);
+        sequencer.getCurrentPattern()->solo = constrain(sequencer.getCurrentPattern()->solo + amt, 0, 1);
+        if (sequencer.getCurrentPattern()->solo)
+        {
+            setAllLEDS(0, 0, 0);
+        }
+    }
+    else if (sqparam == 7)
+    { // SET PATTERN LENGTH
+        auto newPatternLen = constrain(sequencer.getPatternLength(sequencer.playingPattern) + amt, 1, NUM_STEPS);
+        sequencer.setPatternLength(sequencer.playingPattern, newPatternLen);
+        if (sequencer.seqPos[sequencer.playingPattern] >= newPatternLen)
+        {
+            sequencer.seqPos[sequencer.playingPattern] = newPatternLen - 1;
+            sequencer.patternPage[sequencer.playingPattern] = getPatternPage(sequencer.seqPos[sequencer.playingPattern]);
+        }
+    }
+    else if (sqparam == 8)
+    { // SET CLOCK DIV/MULT
+        sequencer.getCurrentPattern()->clockDivMultP = constrain(sequencer.getCurrentPattern()->clockDivMultP + amt, 0, NUM_MULTDIVS - 1);
+    }
+    else if (sqparam == 9)
+    { // SET CV ON/OFF
+        sequencer.getCurrentPattern()->sendCV = constrain(sequencer.getCurrentPattern()->sendCV + amt, 0, 1);
+    }
+    omxDisp.setDirty();
+}
+
+// TODO: break this into separate functions
+void OmxModeSequencer::onEncoderChangedStep(Encoder::Update enc)
+{
+    auto amt = enc.accel(5); // where 5 is the acceleration factor if you want it, 0 if you don't)
+
+    // should be no need to check enc_edit, function will only be called if enc_edit is false
+    if (patternParams && !encoderConfig.enc_edit)
+    { // SEQUENCE PATTERN PARAMS SUB MODE
+        // CHANGE PAGE
+        if (ppparam == 0 || ppparam == 5 || ppparam == 10)
+        {
+            pppage = constrain(pppage + amt, 0, 2); // HARDCODED - FIX WITH SIZE OF PAGES?
+            ppparam = pppage * NUM_DISP_PARAMS;
+        }
+
+        // PAGE ONE
+        if (ppparam == 1)
+        { // SET PLAYING PATTERN
+            sequencer.playingPattern = constrain(sequencer.playingPattern + amt, 0, 7);
+        }
+        if (ppparam == 2)
+        { // SET LENGTH
+            auto newPatternLen = constrain(sequencer.getPatternLength(sequencer.playingPattern) + amt, 1, NUM_STEPS);
+            sequencer.setPatternLength(sequencer.playingPattern, newPatternLen);
+            if (sequencer.seqPos[sequencer.playingPattern] >= newPatternLen)
+            {
+                sequencer.seqPos[sequencer.playingPattern] = newPatternLen - 1;
+                sequencer.patternPage[sequencer.playingPattern] = getPatternPage(sequencer.seqPos[sequencer.playingPattern]);
+            }
+        }
+        if (ppparam == 3)
+        { // SET PATTERN ROTATION
+            int rotator;
+            (u.dir() < 0 ? rotator = -1 : rotator = 1);
+            //							int rotator = constrain(rotcc, (sequencer.PatternLength(sequencer.playingPattern))*-1, sequencer.PatternLength(sequencer.playingPattern));
+            rotationAmt = rotationAmt + rotator;
+            if (rotationAmt < 16 && rotationAmt > -16)
+            { // NUM_STEPS??
+                rotatePattern(sequencer.playingPattern, rotator);
+            }
+            rotationAmt = constrain(rotationAmt, (sequencer.getPatternLength(sequencer.playingPattern) - 1) * -1, sequencer.getPatternLength(sequencer.playingPattern) - 1);
+        }
+
+        if (ppparam == 4)
+        { // SET PATTERN CHANNEL
+            sequencer.getCurrentPattern()->channel = constrain(sequencer.getCurrentPattern()->channel + amt, 0, 15);
+        }
+        // PATTERN PARAMS PAGE 2
+        // TODO: convert to case statement ??
+        if (ppparam == 6)
+        { // SET AUTO START STEP
+            sequencer.getCurrentPattern()->startstep = constrain(sequencer.getCurrentPattern()->startstep + amt, 0, sequencer.getCurrentPattern()->len);
+            // sequencer.getCurrentPattern()->startstep--;
+        }
+        if (ppparam == 7)
+        { // SET AUTO RESET STEP
+            int tempresetstep = sequencer.getCurrentPattern()->autoresetstep + amt;
+            sequencer.getCurrentPattern()->autoresetstep = constrain(tempresetstep, 0, sequencer.getCurrentPattern()->len + 1);
+        }
+        if (ppparam == 8)
+        {                                                                                                                        // SET AUTO RESET FREQUENCY
+            sequencer.getCurrentPattern()->autoresetfreq = constrain(sequencer.getCurrentPattern()->autoresetfreq + amt, 0, 15); // max every 16 times
+        }
+        if (ppparam == 9)
+        {                                                                                                                         // SET AUTO RESET PROB
+            sequencer.getCurrentPattern()->autoresetprob = constrain(sequencer.getCurrentPattern()->autoresetprob + amt, 0, 100); // never, 100% - 33%
+        }
+
+        // PAGE THREE
+        if (ppparam == 11)
+        {                                                                                                                                      // SET CLOCK-DIV-MULT
+            sequencer.getCurrentPattern()->clockDivMultP = constrain(sequencer.getCurrentPattern()->clockDivMultP + amt, 0, NUM_MULTDIVS - 1); // set clock div/mult
+        }
+        if (ppparam == 12)
+        { // SET MIDI SOLO
+            sequencer.getCurrentPattern()->solo = constrain(sequencer.getCurrentPattern()->solo + amt, 0, 1);
+        }
+
+        // STEP RECORD SUB MODE
+    }
+    else if (stepRecord && !enc_edit)
+    {
+        // CHANGE PAGE
+        if (srparam == 0 || srparam == 5)
+        {
+            srpage = constrain(srpage + amt, 0, 1); // HARDCODED - FIX WITH SIZE OF PAGES?
+            srparam = srpage * NUM_DISP_PARAMS;
+        }
+
+        // PAGE ONE
+        if (srparam == 1)
+        { // OCTAVE SELECTION
+            newoctave = constrain(octave + amt, -5, 4);
+            if (newoctave != octave)
+            {
+                octave = newoctave;
+            }
+        }
+        if (srparam == 2)
+        { // STEP SELECTION
+            if (u.dir() > 0)
+            {
+                step_ahead();
+            }
+            else if (u.dir() < 0)
+            {
+                step_back();
+            }
+            selectedStep = sequencer.seqPos[sequencer.playingPattern];
+        }
+        if (srparam == 3)
+        { // SET NOTE NUM
+            int tempNote = getSelectedStep()->note;
+            getSelectedStep()->note = constrain(tempNote + amt, 0, 127);
+        }
+        if (srparam == 4)
+        {
+            //							playingPattern = constrain(playingPattern + amt, 0, 7);
+        }
+        // PAGE TWO
+        if (srparam == 6)
+        { // STEP TYPE
+            changeStepType(amt);
+        }
+        if (srparam == 7)
+        { // STEP PROB
+            int tempProb = getSelectedStep()->prob;
+            getSelectedStep()->prob = constrain(tempProb + amt, 0, 100); // Note Len between 1-16
+        }
+        if (srparam == 8)
+        { // STEP CONDITION
+            int tempCondition = getSelectedStep()->condition;
+            getSelectedStep()->condition = constrain(tempCondition + amt, 0, 35); // 0-32
+        }
+
+        // NOTE SELECT MODE
+    }
+    else if (noteSelect && noteSelection && !enc_edit)
+    {
+        // CHANGE PAGE
+        if (nsparam == 0 || nsparam == 5 || nsparam == 10)
+        {
+            nspage = constrain(nspage + amt, 0, 2); // HARDCODED - FIX WITH SIZE OF PAGES?
+            nsparam = nspage * NUM_DISP_PARAMS;
+        }
+
+        // PAGE THREE
+        if (nsparam > 10 && nsparam < 14)
+        {
+            if (u.dir() < 0)
+            { // RESET PLOCK IF TURN CCW
+                int tempmode = nsparam - 11;
+                getSelectedStep()->params[tempmode] = -1;
+            }
+        }
+        // PAGE ONE
+        if (nsparam == 1)
+        { // SET NOTE NUM
+            int tempNote = getSelectedStep()->note;
+            getSelectedStep()->note = constrain(tempNote + amt, 0, 127);
+        }
+        if (nsparam == 2)
+        { // SET OCTAVE
+            newoctave = constrain(octave + amt, -5, 4);
+            if (newoctave != octave)
+            {
+                octave = newoctave;
+            }
+        }
+        if (nsparam == 3)
+        { // SET VELOCITY
+            int tempVel = getSelectedStep()->vel;
+            getSelectedStep()->vel = constrain(tempVel + amt, 0, 127);
+        }
+        if (nsparam == 4)
+        { // SET NOTE LENGTH
+            int tempLen = getSelectedStep()->len;
+            getSelectedStep()->len = constrain(tempLen + amt, 0, 15); // Note Len between 1-16
+        }
+        // PAGE TWO
+        if (nsparam == 6)
+        { // SET STEP TYPE
+            changeStepType(amt);
+        }
+        if (nsparam == 7)
+        { // SET STEP PROB
+            int tempProb = getSelectedStep()->prob;
+            getSelectedStep()->prob = constrain(tempProb + amt, 0, 100); // Note Len between 1-16
+        }
+        if (nsparam == 8)
+        { // SET STEP TRIG CONDITION
+            int tempCondition = getSelectedStep()->condition;
+            getSelectedStep()->condition = constrain(tempCondition + amt, 0, 35); // 0-32
+        }
+    }
+    else
+    {
+        newtempo = constrain(clockbpm + amt, 40, 300);
+        if (newtempo != clockbpm)
+        {
+            // SET TEMPO HERE
+            clockbpm = newtempo;
+            resetClocks();
+        }
+    }
+    dirtyDisplay = true;
+}
+
+void OmxModeSequencer::onEncoderButtonDown()
+{
+    if (noteSelect && noteSelection && !patternParams)
+    {
+        nsparam = (nsparam + 1) % 15;
+        if (nsparam > 9)
+        {
+            nspage = 2;
+        }
+        else if (nsparam > 4)
+        {
+            nspage = 1;
+        }
+        else
+        {
+            nspage = 0;
+        }
+    }
+    else if (patternParams)
+    {
+        ppparam = (ppparam + 1) % 15;
+        if (ppparam > 9)
+        {
+            pppage = 2;
+        }
+        else if (ppparam > 4)
+        {
+            pppage = 1;
+        }
+        else
+        {
+            pppage = 0;
+        }
+    }
+    else if (stepRecord)
+    {
+        srparam = (srparam + 1) % 10;
+        if (srparam > 4)
+        {
+            srpage = 1;
+        }
+        else
+        {
+            srpage = 0;
+        }
+    }
+    else
+    {
+        sqparam = (sqparam + 1) % 10;
+        if (sqparam > 4)
+        {
+            sqpage = 1;
+        }
+        else
+        {
+            sqpage = 0;
+        }
+    }
+}
+
+void OmxModeSequencer::onEncoderButtonDownLong()
+{
+    if (stepRecord)
+    {
+        resetPatternDefaults(sequencer.playingPattern);
+        clearedFlag = true;
+    }
+}
+
+bool OmxModeSequencer::shouldBlockEncEdit()
+{
+    return stepRecord;
+}
+
+void OmxModeSequencer::onKeyUpdate(OMXKeypadEvent e)
+{
+    int thisKey = e.key();
+    int keyPos = thisKey - 11;
+    int seqKey = keyPos + (sequencer.patternPage[sequencer.playingPattern] * NUM_STEPKEYS);
+
+    // Sequencer row keys
+
+    // ### KEY PRESS EVENTS
+
+    if (e.down() && thisKey != 0)
+    {
+        // set key timer to zero
+        //					keyPressTime[thisKey] = 0;
+
+        // NOTE SELECT
+        if (noteSelect)
+        {
+            if (noteSelection)
+            { // SET NOTE
+                // left and right keys change the octave
+                if (thisKey == 11 || thisKey == 26)
+                {
+                    int amt = thisKey == 11 ? -1 : 1;
+                    newoctave = constrain(octave + amt, -5, 4);
+                    if (newoctave != octave)
+                    {
+                        octave = newoctave;
+                    }
+                    // otherwise select the note
+                }
+                else
+                {
+                    stepSelect = false;
+                    selectedNote = thisKey;
+                    int adjnote = notes[thisKey] + (octave * 12);
+                    getSelectedStep()->note = adjnote;
+                    if (!sequencer.playing)
+                    {
+                        seqNoteOn(thisKey, defaultVelocity, sequencer.playingPattern);
+                    }
+                }
+                // see RELEASE events for more
+                omxDisp.setDirty();
+            }
+            else if (thisKey == 1)
+            {
+            }
+            else if (thisKey == 2)
+            {
+            }
+            else if (thisKey > 2 && thisKey < 11)
+            { // Pattern select keys
+                sequencer.playingPattern = thisKey - 3;
+                omxDisp.setDirty();
+            }
+            else if (thisKey > 10)
+            {
+                selectedStep = seqKey; // was keyPos // set noteSelection to this step
+                stepSelect = true;
+                noteSelection = true;
+                omxDisp.setDirty();
+            }
+
+            // PATTERN PARAMS
+        }
+        else if (patternParams)
+        {
+            if (thisKey == 1)
+            { // F1
+            }
+            else if (thisKey == 2)
+            { // F2
+            }
+            else if (thisKey > 2 && thisKey < 11)
+            { // Pattern select keys
+
+                sequencer.playingPattern = thisKey - 3;
+
+                // COPY / PASTE / CLEAR
+                if (keyState[1] && !keyState[2])
+                {
+                    copyPattern(sequencer.playingPattern);
+                    displayMessagef("COPIED P-%d", sequencer.playingPattern + 1);
+                }
+                else if (!keyState[1] && keyState[2])
+                {
+                    pastePattern(sequencer.playingPattern);
+                    displayMessagef("PASTED P-%d", sequencer.playingPattern + 1);
+                }
+                else if (keyState[1] && keyState[2])
+                {
+                    clearPattern(sequencer.playingPattern);
+                    displayMessagef("CLEARED P-%d", sequencer.playingPattern + 1);
+                }
+
+                omxDisp.setDirty();
+            }
+            else if (thisKey > 10)
+            {
+                // set pattern length with key
+                auto newPatternLen = thisKey - 10;
+                sequencer.setPatternLength(sequencer.playingPattern, newPatternLen);
+                if (sequencer.seqPos[sequencer.playingPattern] >= newPatternLen)
+                {
+                    sequencer.seqPos[sequencer.playingPattern] = newPatternLen - 1;
+                    sequencer.patternPage[sequencer.playingPattern] = getPatternPage(sequencer.seqPos[sequencer.playingPattern]);
+                }
+                omxDisp.setDirty();
+            }
+
+            // STEP RECORD
+        }
+        else if (stepRecord)
+        {
+            selectedNote = thisKey;
+            selectedStep = sequencer.seqPos[sequencer.playingPattern];
+
+            int adjnote = notes[thisKey] + (octave * 12);
+            getSelectedStep()->note = adjnote;
+
+            if (!sequencer.playing)
+            {
+                seqNoteOn(thisKey, defaultVelocity, sequencer.playingPattern);
+            } // see RELEASE events for more
+            stepDirty = true;
+            omxDisp.setDirty();
+
+            // MIDI SOLO
+        }
+        else if (sequencer.getCurrentPattern()->solo)
+        {
+            midiNoteOn(thisKey, defaultVelocity, sequencer.getCurrentPattern()->channel + 1);
+
+            // REGULAR SEQ MODE
+        }
+        else
+        {
+            if (keyState[1] && keyState[2])
+            {
+                seqPages = true;
+            }
+            if (thisKey == 1)
+            {
+                //							seqResetFlag = true;					// RESET ALL SEQUENCES TO FIRST/LAST STEP
+                // MOVED DOWN TO AUX KEY
+            }
+            else if (thisKey == 2)
+            { // CHANGE PATTERN DIRECTION
+              //							sequencer.getCurrentPattern()->reverse = !sequencer.getCurrentPattern()->reverse;
+
+                // BLACK KEYS - PATTERNS
+            }
+            else if (thisKey > 2 && thisKey < 11)
+            { // Pattern select
+
+                // CHECK keyState[] FOR LONG PRESS THINGS
+
+                // If ONLY KEY 1 is down + pattern is not playing = STEP RECORD
+                if (keyState[1] && !keyState[2] && !sequencer.playing)
+                {
+                    sequencer.playingPattern = thisKey - 3;
+                    sequencer.seqPos[sequencer.playingPattern] = 0;
+                    sequencer.patternPage[sequencer.playingPattern] = 0; // Step Record always starts from first page
+                    stepRecord = true;
+                    displayMessagef("STEP RECORD");
+                    //								omxDisp.setDirty();;
+
+                    // If KEY 2 is down + pattern = PATTERN MUTE
+                }
+                else if (keyState[2])
+                {
+                    if (sequencer.getPattern(thisKey - 3)->mute)
+                    {
+                        displayMessagef("UNMUTE P-%d", (thisKey - 3) + 1);
+                    }
+                    else
+                    {
+                        displayMessagef("MUTE P-%d", (thisKey - 3) + 1);
+                    }
+                    sequencer.getPattern(thisKey - 3)->mute = !sequencer.getPattern(thisKey - 3)->mute;
+                }
+                else
+                {
+                    sequencer.playingPattern = thisKey - 3;
+                }
+                omxDisp.setDirty();
+
+                // SEQUENCE 1-16 STEP KEYS
+            }
+            else if (thisKey > 10)
+            {
+
+                if (keyState[1] && keyState[2])
+                { // F1+F2 HOLD
+                    if (!stepRecord)
+                    { // IGNORE LONG PRESSES IN STEP RECORD
+                        if (keyPos <= getPatternPage(sequencer.getCurrentPattern()->len))
+                        {
+                            sequencer.patternPage[sequencer.playingPattern] = keyPos;
+                        }
+                        displayMessagef("PATT PAGE %d", keyPos + 1);
+                    }
+                }
+                else if (keyState[1])
+                { // F1 HOLD
+                    if (!stepRecord && !patternParams)
+                    {                                // IGNORE LONG PRESSES IN STEP RECORD and Pattern Params
+                        selectedStep = thisKey - 11; // set noteSelection to this step
+                        noteSelect = true;
+                        stepSelect = true;
+                        noteSelection = true;
+                        omxDisp.setDirty();
+                        displayMessagef("NOTE SELECT");
+                        // re-toggle the key you just held
+                        //										if (getSelectedStep()->trig == TRIGTYPE_PLAY || getSelectedStep()->trig == TRIGTYPE_MUTE ) {
+                        //											getSelectedStep()->trig = (getSelectedStep()->trig == TRIGTYPE_PLAY ) ? TRIGTYPE_MUTE : TRIGTYPE_PLAY;
+                        //										}
+                    }
+                }
+                else if (keyState[2])
+                { // F2 HOLD
+                }
+                else
+                {
+                    // TOGGLE STEP ON/OFF
+                    if (sequencer.getCurrentPattern()->steps[seqKey].trig == TRIGTYPE_PLAY || sequencer.getCurrentPattern()->steps[seqKey].trig == TRIGTYPE_MUTE)
+                    {
+                        sequencer.getCurrentPattern()->steps[seqKey].trig = (sequencer.getCurrentPattern()->steps[seqKey].trig == TRIGTYPE_PLAY) ? TRIGTYPE_MUTE : TRIGTYPE_PLAY;
+                    }
+                }
+            }
+        }
+    }
+
+    // ### KEY RELEASE EVENTS
+
+    if (!e.down() && thisKey != 0)
+    {
+        // MIDI SOLO
+        if (sequencer.getCurrentPattern()->solo)
+        {
+            midiNoteOff(thisKey, sequencer.getCurrentPattern()->channel + 1);
+        }
+    }
+
+    if (!e.down() && thisKey != 0 && (noteSelection || stepRecord) && selectedNote > 0)
+    {
+        if (!sequencer.playing)
+        {
+            seqNoteOff(thisKey, sequencer.playingPattern);
+        }
+        if (stepRecord && stepDirty)
+        {
+            step_ahead();
+            stepDirty = false;
+            // EXIT STEP RECORD AFTER THE LAST STEP IN PATTERN
+            if (sequencer.seqPos[sequencer.playingPattern] == 0)
+            {
+                stepRecord = false;
+            }
+        }
+    }
+
+    // AUX KEY PRESS EVENTS
+
+    if (e.down() && thisKey == 0)
+    {
+
+        if (noteSelect)
+        {
+            if (noteSelection)
+            {
+                selectedStep = 0;
+                selectedNote = 0;
+            }
+            else
+            {
+            }
+            noteSelection = false;
+            noteSelect = !noteSelect;
+            omxDisp.setDirty();
+        }
+        else if (patternParams)
+        {
+            patternParams = !patternParams;
+            omxDisp.setDirty();
+        }
+        else if (stepRecord)
+        {
+            stepRecord = !stepRecord;
+            omxDisp.setDirty();
+        }
+        else if (seqPages)
+        {
+            seqPages = false;
+        }
+        else
+        {
+            if (keyState[1] || keyState[2])
+            { // CHECK keyState[] FOR LONG PRESS OF FUNC KEYS
+                if (keyState[1])
+                {
+                    sequencer.seqResetFlag = true; // RESET ALL SEQUENCES TO FIRST/LAST STEP
+                    displayMessagef("RESET");
+                }
+                else if (keyState[2])
+                { // CHANGE PATTERN DIRECTION
+                    sequencer.getCurrentPattern()->reverse = !sequencer.getCurrentPattern()->reverse;
+                    if (sequencer.getCurrentPattern()->reverse)
+                    {
+                        displayMessagef("<< REV");
+                    }
+                    else
+                    {
+                        displayMessagef("FWD >>");
+                    }
+                }
+                omxDisp.setDirty();
+            }
+            else
+            {
+                if (sequencer.playing)
+                {
+                    // stop transport
+                    sequencer.playing = 0;
+                    allNotesOff();
+                    //							Serial.println("stop transport");
+                    seqStop();
+                }
+                else
+                {
+                    // start transport
+                    //							Serial.println("start transport");
+                    seqStart();
+                }
+            }
+        }
+
+        // AUX KEY RELEASE EVENTS
+    }
+    else if (!e.down() && thisKey == 0)
+    {
+    }
+
+    //				strip.show();
+}
+
+void OmxModeSequencer::onKeyHeldUpdate(OMXKeypadEvent e)
+{
+    if (!sequencer.getCurrentPattern()->solo)
+    {
+        // TODO: access key state directly in omx_keypad.h
+        if (keyState[1] && keyState[2])
+        {
+            seqPages = true;
+        }
+        else if (!keyState[1] && !keyState[2])
+        { // SKIP LONG PRESS IF FUNC KEYS ARE ALREDY HELD
+            if (thisKey > 2 && thisKey < 11)
+            { // skip AUX key, get pattern keys
+                patternParams = true;
+                omxDisp.setDirty();
+                displayMessagef("PATT PARAMS");
+            }
+            else if (thisKey > 10)
+            {
+                if (!stepRecord && !patternParams)
+                {                                                                                                     // IGNORE LONG PRESSES IN STEP RECORD and Pattern Params
+                    selectedStep = (thisKey - 11) + (sequencer.patternPage[sequencer.playingPattern] * NUM_STEPKEYS); // set noteSelection to this step
+                    noteSelect = true;
+                    stepSelect = true;
+                    noteSelection = true;
+                    omxDisp.setDirty();
+                    displayMessagef("NOTE SELECT");
+                    // re-toggle the key you just held
+                    //									if ( getSelectedStep()->trig == TRIGTYPE_PLAY || getSelectedStep()->trig == TRIGTYPE_MUTE ) {
+                    //										getSelectedStep()->trig = ( getSelectedStep()->trig == TRIGTYPE_PLAY ) ? TRIGTYPE_MUTE : TRIGTYPE_PLAY;
+                    //									}
+                }
+            }
+        }
+    }
+}
+
+void OmxModeSequencer::showCurrentStep(int patternNum)
+{
+
+    omxLeds.updateLeds();
+
+    bool blinkState = omxLeds.getBlinkState();
+    bool slowBlinkState = omxLeds.getSlowBlinkState();
+
+    // AUX KEY
+
+    if (sequencer.playing && blinkState)
+    {
+        strip.setPixelColor(0, WHITE);
+    }
+    else if (noteSelect && blinkState)
+    {
+        strip.setPixelColor(0, NOTESEL);
+    }
+    else if (patternParams && blinkState)
+    {
+        strip.setPixelColor(0, seqColors[patternNum]);
+    }
+    else if (stepRecord && blinkState)
+    {
+        strip.setPixelColor(0, seqColors[patternNum]);
+    }
+    else
+    {
+        switch (sysSettings.omxMode)
+        {
+        case MODE_S1:
+            strip.setPixelColor(0, SEQ1C);
+            break;
+        case MODE_S2:
+            strip.setPixelColor(0, SEQ2C);
+            break;
+        default:
+            strip.setPixelColor(0, LEDOFF);
+            break;
+        }
+    }
+
+    if (sequencer.getPattern(patternNum)->mute)
+    {
+        colorConfig.stepColor = muteColors[patternNum];
+    }
+    else
+    {
+        colorConfig.stepColor = seqColors[patternNum];
+        colorConfig.muteColor = muteColors[patternNum];
+    }
+
+    auto currentpage = sequencer.patternPage[patternNum];
+    auto pagestepstart = (currentpage * NUM_STEPKEYS);
+
+    if (noteSelect && noteSelection)
+    {
+        // 27 LEDS so use LED_COUNT
+        for (int j = 1; j < LED_COUNT; j++)
+        {
+            auto pixelpos = j;
+            auto selectedStepPixel = (selectedStep % NUM_STEPKEYS) + 11;
+
+            if (pixelpos == selectedNote)
+            {
+                strip.setPixelColor(pixelpos, HALFWHITE);
+            }
+            else if (pixelpos == selectedStepPixel)
+            {
+                strip.setPixelColor(pixelpos, SEQSTEP);
+            }
+            else
+            {
+                strip.setPixelColor(pixelpos, LEDOFF);
+            }
+
+            // Blink left/right keys for octave select indicators.
+            auto color1 = blinkState ? ORANGE : WHITE;
+            auto color2 = blinkState ? RBLUE : WHITE;
+            strip.setPixelColor(11, color1);
+            strip.setPixelColor(26, color2);
+        }
+    }
+    else if (stepRecord)
+    { // STEP RECORD
+        //		int numPages = ceil(float(sequencer.getPatternLength(patternNum))/float(NUM_STEPKEYS));
+
+        // BLANK THE TOP ROW
+        for (int j = 1; j < LED_COUNT - NUM_STEPKEYS; j++)
+        {
+            strip.setPixelColor(j, LEDOFF);
+        }
+
+        for (int j = pagestepstart; j < (pagestepstart + NUM_STEPKEYS); j++)
+        {
+            auto pixelpos = j - pagestepstart + 11;
+            //			if (j < sequencer.getPatternLength(patternNum)){
+            // ONLY DO LEDS FOR THE CURRENT PAGE
+            if (j == sequencer.seqPos[sequencer.playingPattern])
+            {
+                strip.setPixelColor(pixelpos, SEQCHASE);
+            }
+            else if (pixelpos != selectedNote)
+            {
+                strip.setPixelColor(pixelpos, LEDOFF);
+            }
+            //			} else  {
+            //				strip.setPixelColor(pixelpos, LEDOFF);
+            //			}
+        }
+    }
+    else if (sequencer.getCurrentPattern()->solo)
+    { // MIDI SOLO
+
+        //		for(int i = 0; i < NUM_STEPKEYS; i++){
+        //			if (i == seqPos[patternNum]){
+        //				if (playing){
+        //					strip.setPixelColor(i+11, SEQCHASE); // step chase
+        //				} else {
+        //					strip.setPixelColor(i+11, LEDOFF);  // DO WE NEED TO MARK PLAYHEAD WHEN STOPPED?
+        //				}
+        //			} else {
+        //				strip.setPixelColor(i+11, LEDOFF);
+        //			}
+        //		}
+    }
+    else if (seqPages)
+    {
+        // BLINK F1+F2
+        auto color1 = blinkState ? FUNKONE : LEDOFF;
+        auto color2 = blinkState ? FUNKTWO : LEDOFF;
+        strip.setPixelColor(1, color1);
+        strip.setPixelColor(2, color2);
+
+        // TURN OFF LEDS
+        // 27 LEDS so use LED_COUNT
+        for (int j = 3; j < LED_COUNT; j++)
+        { // START WITH LEDS AFTER F-KEYS
+            strip.setPixelColor(j, LEDOFF);
+        }
+        // SHOW LEDS FOR WHAT PAGE OF SEQ PATTERN YOURE ON
+        auto len = (sequencer.getPattern(patternNum)->len / NUM_STEPKEYS);
+        for (int h = 0; h <= len; h++)
+        {
+            auto currentpage = sequencer.patternPage[patternNum];
+            auto color = sequencePageColors[h];
+            if (h == currentpage)
+            {
+                color = blinkState ? sequencePageColors[currentpage] : LEDOFF;
+            }
+            strip.setPixelColor(11 + h, color);
+        }
+    }
+    else
+    {
+        for (int j = 1; j < LED_COUNT; j++)
+        {
+            if (j < sequencer.getPatternLength(patternNum) + 11)
+            {
+                if (j == 1)
+                {
+                    // NOTE SELECT / F1
+                    if (midiSettings.keyState[j] && blinkState)
+                    {
+                        strip.setPixelColor(j, LEDOFF);
+                    }
+                    else
+                    {
+                        strip.setPixelColor(j, FUNKONE);
+                    }
+                }
+                else if (j == 2)
+                {
+                    // PATTERN PARAMS / F2
+                    if (midiSettings.keyState[j] && blinkState)
+                    {
+                        strip.setPixelColor(j, LEDOFF);
+                    }
+                    else
+                    {
+                        strip.setPixelColor(j, FUNKTWO);
+                    }
+                }
+                else if (j == patternNum + 3)
+                { // PATTERN SELECT
+                    strip.setPixelColor(j, colorConfig.stepColor);
+                    if (patternParams && blinkState)
+                    {
+                        strip.setPixelColor(j, LEDOFF);
+                    }
+                }
+                else
+                {
+                    strip.setPixelColor(j, LEDOFF);
+                }
+            }
+            else
+            {
+                strip.setPixelColor(j, LEDOFF);
+            }
+        }
+
+        auto pattern = sequencer.getPattern(patternNum);
+        auto steps = pattern->steps;
+        auto currentpage = sequencer.patternPage[patternNum];
+        auto pagestepstart = (currentpage * NUM_STEPKEYS);
+
+        // WHAT TO DO HERE FOR MULTIPLE PAGES
+        // NUM_STEPKEYS or NUM_STEPS INSTEAD?
+        for (int i = pagestepstart; i < (pagestepstart + NUM_STEPKEYS); i++)
+        {
+            if (i < sequencer.getPatternLength(patternNum))
+            {
+
+                // ONLY DO LEDS FOR THE CURRENT PAGE
+                auto pixelpos = i - pagestepstart + 11;
+                //				if (patternParams){
+                // 					strip.setPixelColor(pixelpos, SEQMARKER);
+                // 				}
+
+                if (i % 4 == 0)
+                { // MARK GROUPS OF 4
+                    if (i == sequencer.seqPos[patternNum])
+                    {
+                        if (sequencer.playing)
+                        {
+                            strip.setPixelColor(pixelpos, SEQCHASE); // step chase
+                        }
+                        else if (steps[i].trig == TRIGTYPE_PLAY)
+                        {
+                            if (steps[i].stepType != STEPTYPE_NONE)
+                            {
+                                if (slowBlinkState)
+                                {
+                                    strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP EVENT COLOR
+                                }
+                                else
+                                {
+                                    strip.setPixelColor(pixelpos, colorConfig.muteColor); // STEP EVENT COLOR
+                                }
+                            }
+                            else
+                            {
+                                strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP ON COLOR
+                            }
+                        }
+                        else if (steps[i].trig == TRIGTYPE_MUTE)
+                        {
+                            strip.setPixelColor(pixelpos, SEQMARKER);
+                        }
+                    }
+                    else if (steps[i].trig == TRIGTYPE_PLAY)
+                    {
+                        if (steps[i].stepType != STEPTYPE_NONE)
+                        {
+                            if (slowBlinkState)
+                            {
+                                strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP EVENT COLOR
+                            }
+                            else
+                            {
+                                strip.setPixelColor(pixelpos, colorConfig.muteColor); // STEP EVENT COLOR
+                            }
+                        }
+                        else
+                        {
+                            strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP ON COLOR
+                        }
+                    }
+                    else if (steps[i].trig == TRIGTYPE_MUTE)
+                    {
+                        strip.setPixelColor(pixelpos, SEQMARKER);
+                    }
+                }
+                else if (i == sequencer.seqPos[patternNum])
+                { // STEP CHASE
+                    if (sequencer.playing)
+                    {
+                        strip.setPixelColor(pixelpos, SEQCHASE);
+                    }
+                    else if (steps[i].trig == TRIGTYPE_PLAY)
+                    {
+                        if (steps[i].stepType != STEPTYPE_NONE)
+                        {
+                            if (slowBlinkState)
+                            {
+                                strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP EVENT COLOR
+                            }
+                            else
+                            {
+                                strip.setPixelColor(pixelpos, colorConfig.muteColor); // STEP EVENT COLOR
+                            }
+                        }
+                        else
+                        {
+                            strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP ON COLOR
+                        }
+                    }
+                    else if (!patternParams && sequencer.patterns[patternNum].steps[i].trig == TRIGTYPE_MUTE)
+                    {
+                        strip.setPixelColor(pixelpos, LEDOFF); // DO WE NEED TO MARK PLAYHEAD WHEN STOPPED?
+                    }
+                    else if (patternParams)
+                    {
+                        strip.setPixelColor(pixelpos, SEQMARKER);
+                    }
+                }
+                else if (steps[i].trig == TRIGTYPE_PLAY)
+                {
+                    if (steps[i].stepType != STEPTYPE_NONE)
+                    {
+                        if (slowBlinkState)
+                        {
+                            strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP EVENT COLOR
+                        }
+                        else
+                        {
+                            strip.setPixelColor(pixelpos, colorConfig.muteColor); // STEP EVENT COLOR
+                        }
+                    }
+                    else
+                    {
+                        strip.setPixelColor(pixelpos, colorConfig.stepColor); // STEP ON COLOR
+                    }
+                }
+                else if (!patternParams && steps[i].trig == TRIGTYPE_MUTE)
+                {
+                    strip.setPixelColor(pixelpos, LEDOFF);
+                }
+                else if (patternParams)
+                {
+                    strip.setPixelColor(pixelpos, SEQMARKER);
+                }
+            }
+        }
+    }
+    omxLeds.setDirty();
+}
+
+void OmxModeSequencer::updateLEDs()
+{
+}

--- a/OMX-27-firmware/omx_mode_sequencer.cpp
+++ b/OMX-27-firmware/omx_mode_sequencer.cpp
@@ -67,6 +67,9 @@ void OmxModeSequencer::loopUpdate()
     { // S2
         doStepS2();
     }
+
+    // renders leds for the playing pattern
+    showCurrentStep(sequencer.playingPattern);
 }
 
 void OmxModeSequencer::onEncoderChanged(Encoder::Update enc)
@@ -827,8 +830,9 @@ void OmxModeSequencer::onKeyHeldUpdate(OMXKeypadEvent e)
 
 void OmxModeSequencer::showCurrentStep(int patternNum)
 {
+	if(sysSettings.screenSaverMode && !sequencer.playing) return; // Screensaver active and not playing, don't update sequencer LEDs. 
 
-    omxLeds.updateLeds();
+    omxLeds.updateBlinkStates();
 
     bool blinkState = omxLeds.getBlinkState();
     bool slowBlinkState = omxLeds.getSlowBlinkState();

--- a/OMX-27-firmware/omx_mode_sequencer.cpp
+++ b/OMX-27-firmware/omx_mode_sequencer.cpp
@@ -64,6 +64,7 @@ void OmxModeSequencer::onEncoderChanged(Encoder::Update enc)
 
 void OmxModeSequencer::onEncoderChangedNorm(Encoder::Update enc)
 {
+    /*
     auto amt = enc.accel(5); // where 5 is the acceleration factor if you want it, 0 if you don't)
 
     // CHANGE PAGE
@@ -135,11 +136,13 @@ void OmxModeSequencer::onEncoderChangedNorm(Encoder::Update enc)
         sequencer.getCurrentPattern()->sendCV = constrain(sequencer.getCurrentPattern()->sendCV + amt, 0, 1);
     }
     omxDisp.setDirty();
+    */
 }
 
 // TODO: break this into separate functions
 void OmxModeSequencer::onEncoderChangedStep(Encoder::Update enc)
 {
+    /*
     auto amt = enc.accel(5); // where 5 is the acceleration factor if you want it, 0 if you don't)
 
     // should be no need to check enc_edit, function will only be called if enc_edit is false
@@ -343,10 +346,12 @@ void OmxModeSequencer::onEncoderChangedStep(Encoder::Update enc)
         }
     }
     dirtyDisplay = true;
+    */
 }
 
 void OmxModeSequencer::onEncoderButtonDown()
 {
+    /*
     if (noteSelect && noteSelection && !patternParams)
     {
         nsparam = (nsparam + 1) % 15;
@@ -403,6 +408,7 @@ void OmxModeSequencer::onEncoderButtonDown()
             sqpage = 0;
         }
     }
+    */
 }
 
 void OmxModeSequencer::onEncoderButtonDownLong()
@@ -421,6 +427,7 @@ bool OmxModeSequencer::shouldBlockEncEdit()
 
 void OmxModeSequencer::onKeyUpdate(OMXKeypadEvent e)
 {
+    /*
     int thisKey = e.key();
     int keyPos = thisKey - 11;
     int seqKey = keyPos + (sequencer.patternPage[sequencer.playingPattern] * NUM_STEPKEYS);
@@ -765,10 +772,12 @@ void OmxModeSequencer::onKeyUpdate(OMXKeypadEvent e)
     }
 
     //				strip.show();
+    */
 }
 
 void OmxModeSequencer::onKeyHeldUpdate(OMXKeypadEvent e)
 {
+    /*
     if (!sequencer.getCurrentPattern()->solo)
     {
         // TODO: access key state directly in omx_keypad.h
@@ -802,10 +811,12 @@ void OmxModeSequencer::onKeyHeldUpdate(OMXKeypadEvent e)
             }
         }
     }
+    */
 }
 
 void OmxModeSequencer::showCurrentStep(int patternNum)
 {
+    /*
 
     omxLeds.updateLeds();
 
@@ -1141,6 +1152,7 @@ void OmxModeSequencer::showCurrentStep(int patternNum)
         }
     }
     omxLeds.setDirty();
+    */
 }
 
 void OmxModeSequencer::updateLEDs()
@@ -1149,6 +1161,7 @@ void OmxModeSequencer::updateLEDs()
 
 void OmxModeSequencer::onDisplayUpdate()
 {
+    /*
     // MIDI SOLO
     if (sequencer.getCurrentPattern()->solo)
     {
@@ -1216,6 +1229,7 @@ void OmxModeSequencer::onDisplayUpdate()
             }
         }
     }
+    */
 }
 
 void OmxModeSequencer::initPatterns()

--- a/OMX-27-firmware/omx_mode_sequencer.cpp
+++ b/OMX-27-firmware/omx_mode_sequencer.cpp
@@ -18,7 +18,7 @@ void OmxModeSequencer::onModeActivated()
     }
 }
 
-void OmxModeSequencer::OnPotChanged(int potIndex, int potValue)
+void OmxModeSequencer::onPotChanged(int potIndex, int potValue)
 {
     if (seqConfig.noteSelect && seqConfig.noteSelection)
     { // note selection - do P-Locks
@@ -429,7 +429,7 @@ void OmxModeSequencer::onEncoderButtonDownLong()
     if (seqConfig.stepRecord)
     {
         resetPatternDefaults(sequencer.playingPattern);
-        clearedFlag = true;
+        // clearedFlag = true;
     }
 }
 

--- a/OMX-27-firmware/omx_mode_sequencer.h
+++ b/OMX-27-firmware/omx_mode_sequencer.h
@@ -8,6 +8,8 @@ public:
     OmxModeSequencer() {}
     ~OmxModeSequencer() {}
 
+    void InitSetup() override;
+
     void OnPotChanged(int potIndex, int potValue) override;
 
     // Should be part of LED update, intertangled with the sequencer class which is calling it in main FW code.
@@ -24,7 +26,15 @@ public:
     void onKeyUpdate(OMXKeypadEvent e) override;
     void onKeyHeldUpdate(OMXKeypadEvent e) override;
 
+    void onDisplayUpdate() override;
+
+    void setSeq2Mode()
+    {
+        seq2Mode = true;
+    }
+
 private:
+    bool seq2Mode = false;
     bool patternParams = false;
     bool seqPages = false;
 
@@ -53,4 +63,6 @@ private:
 
     void onEncoderChangedNorm(Encoder::Update enc);
     void onEncoderChangedStep(Encoder::Update enc);
+
+    void initPatterns();
 };

--- a/OMX-27-firmware/omx_mode_sequencer.h
+++ b/OMX-27-firmware/omx_mode_sequencer.h
@@ -10,7 +10,13 @@ public:
 
     void InitSetup() override;
 
+    void initPatterns(); // Initializes all patterns
+
+    void onModeActivated() override;
+
     void OnPotChanged(int potIndex, int potValue) override;
+
+    void loopUpdate() override;
 
     // Should be part of LED update, intertangled with the sequencer class which is calling it in main FW code.
     void showCurrentStep(int patternNum);
@@ -28,33 +34,44 @@ public:
 
     void onDisplayUpdate() override;
 
+    void setSeq1Mode()
+    {
+        seq2Mode = false;
+    }
+
     void setSeq2Mode()
     {
         seq2Mode = true;
     }
 
 private:
+    bool initSetup = false;
     bool seq2Mode = false;
-    bool patternParams = false;
-    bool seqPages = false;
 
-    bool noteSelect = false;
-    bool noteSelection = false;
+    // bool omxseqpatternParams = false;
+    // bool omxseqseqPages = false;
 
-    int selectedNote = 0;
-    int selectedStep = 0;
-    bool stepSelect = false;
-    bool stepRecord = false;
-    bool stepDirty = false;
+    // bool omxseqnoteSelect = false;
+    // bool omxseqnoteSelection = false;
 
-    int pppage = 0;
-    int sqpage = 0;
-    int srpage = 0;
+    // int omxseqselectedNote = 0;
+    // int omxSeqSelectedStep = 0;
+    // bool omxseqstepSelect = false;
+    // bool omxseqstepRecord = false;
+    // bool omxseqstepDirty = false;
 
-    int nsparam = 0; // note select params
-    int ppparam = 0; // pattern params
-    int sqparam = 0; // seq params
-    int srparam = 0; // step record params
+    // int omxSeqnspage = 0;
+    // int omxSeqpppage = 0;
+    // int omxSeqsqpage = 0;
+    // int omxSeqsrpage = 0;
+
+    // int omxSeqnsparam = 0; // note select params
+    // int omxSeqppparam = 0; // pattern params
+    // int omxSeqsqparam = 0; // seq params
+    // int omxSeqsrparam = 0; // step record params
+
+    // volatile unsigned long noteon_micros;
+    // volatile unsigned long noteoff_micros;
 
     // These do not appear to be used
     bool copiedFlag = false;
@@ -64,5 +81,4 @@ private:
     void onEncoderChangedNorm(Encoder::Update enc);
     void onEncoderChangedStep(Encoder::Update enc);
 
-    void initPatterns();
 };

--- a/OMX-27-firmware/omx_mode_sequencer.h
+++ b/OMX-27-firmware/omx_mode_sequencer.h
@@ -14,7 +14,7 @@ public:
 
     void onModeActivated() override;
 
-    void OnPotChanged(int potIndex, int potValue) override;
+    void onPotChanged(int potIndex, int potValue) override;
 
     void loopUpdate() override;
 
@@ -48,35 +48,10 @@ private:
     bool initSetup = false;
     bool seq2Mode = false;
 
-    // bool omxseqpatternParams = false;
-    // bool omxseqseqPages = false;
-
-    // bool omxseqnoteSelect = false;
-    // bool omxseqnoteSelection = false;
-
-    // int omxseqselectedNote = 0;
-    // int omxSeqSelectedStep = 0;
-    // bool omxseqstepSelect = false;
-    // bool omxseqstepRecord = false;
-    // bool omxseqstepDirty = false;
-
-    // int omxSeqnspage = 0;
-    // int omxSeqpppage = 0;
-    // int omxSeqsqpage = 0;
-    // int omxSeqsrpage = 0;
-
-    // int omxSeqnsparam = 0; // note select params
-    // int omxSeqppparam = 0; // pattern params
-    // int omxSeqsqparam = 0; // seq params
-    // int omxSeqsrparam = 0; // step record params
-
-    // volatile unsigned long noteon_micros;
-    // volatile unsigned long noteoff_micros;
-
     // These do not appear to be used
-    bool copiedFlag = false;
-    bool pastedFlag = false;
-    bool clearedFlag = false;
+    // bool copiedFlag = false;
+    // bool pastedFlag = false;
+    // bool clearedFlag = false;
 
     void onEncoderChangedNorm(Encoder::Update enc);
     void onEncoderChangedStep(Encoder::Update enc);

--- a/OMX-27-firmware/omx_mode_sequencer.h
+++ b/OMX-27-firmware/omx_mode_sequencer.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "omx_mode_interface.h"
+
+class OmxModeSequencer : public OmxModeInterface
+{
+public:
+    OmxModeSequencer() {}
+    ~OmxModeSequencer() {}
+
+    void OnPotChanged(int potIndex, int potValue) override;
+
+    // Should be part of LED update, intertangled with the sequencer class which is calling it in main FW code.
+    void showCurrentStep(int patternNum);
+
+    void updateLEDs() override;
+
+    void onEncoderChanged(Encoder::Update enc) override;
+    void onEncoderButtonDown() override;
+    void onEncoderButtonDownLong() override;
+
+    bool shouldBlockEncEdit() override;
+
+    void onKeyUpdate(OMXKeypadEvent e) override;
+    void onKeyHeldUpdate(OMXKeypadEvent e) override;
+
+private:
+    bool patternParams = false;
+    bool seqPages = false;
+
+    bool noteSelect = false;
+    bool noteSelection = false;
+
+    int selectedNote = 0;
+    int selectedStep = 0;
+    bool stepSelect = false;
+    bool stepRecord = false;
+    bool stepDirty = false;
+
+    int pppage = 0;
+    int sqpage = 0;
+    int srpage = 0;
+
+    int nsparam = 0; // note select params
+    int ppparam = 0; // pattern params
+    int sqparam = 0; // seq params
+    int srparam = 0; // step record params
+
+    // These do not appear to be used
+    bool copiedFlag = false;
+    bool pastedFlag = false;
+    bool clearedFlag = false;
+
+    void onEncoderChangedNorm(Encoder::Update enc);
+    void onEncoderChangedStep(Encoder::Update enc);
+};

--- a/OMX-27-firmware/omx_screensaver.cpp
+++ b/OMX-27-firmware/omx_screensaver.cpp
@@ -96,3 +96,10 @@ void OmxScreensaver::resetCounter()
 {
     screenSaverCounter = 0;
 }
+
+void OmxScreensaver::onDisplayUpdate()
+{
+    updateLEDs();
+	omxDisp.clearDisplay();
+}
+

--- a/OMX-27-firmware/omx_screensaver.cpp
+++ b/OMX-27-firmware/omx_screensaver.cpp
@@ -4,7 +4,7 @@
 #include "omx_disp.h"
 #include "omx_leds.h"
 
-void OmxScreensaver::OnPotChanged(int potIndex, int potValue)
+void OmxScreensaver::onPotChanged(int potIndex, int potValue)
 {
     colorConfig.screensaverColor = potSettings.analog[4]->getValue() * 4; // value is 0-32764 for strip.ColorHSV
 

--- a/OMX-27-firmware/omx_screensaver.cpp
+++ b/OMX-27-firmware/omx_screensaver.cpp
@@ -1,0 +1,98 @@
+#include "omx_screensaver.h"
+#include "config.h"
+#include "omx_util.h"
+#include "omx_disp.h"
+#include "omx_leds.h"
+
+void OmxScreensaver::OnPotChanged(int potIndex, int potValue)
+{
+    colorConfig.screensaverColor = potSettings.analog[4]->getValue() * 4; // value is 0-32764 for strip.ColorHSV
+
+    // reset screensaver
+    if (potSettings.analog[0]->hasChanged() || potSettings.analog[1]->hasChanged() || potSettings.analog[2]->hasChanged() || potSettings.analog[3]->hasChanged())
+    {
+        screenSaverCounter = 0;
+    }
+}
+
+void OmxScreensaver::updateScreenSaverState()
+{
+    if (screenSaverCounter > screensaverInterval ){
+		screenSaverActive = true;
+	} else if (screenSaverCounter < 10){
+		ssstep = 0;
+		ssloop = 0;
+//		setAllLEDS(0,0,0);
+		screenSaverActive = false;
+		nextStepTimeSS = millis();
+	} else {
+		screenSaverActive = false;
+		nextStepTimeSS = millis();
+	}
+}
+
+bool OmxScreensaver::shouldShowScreenSaver()
+{
+    return screenSaverActive;
+}
+
+void OmxScreensaver::onEncoderChanged(Encoder::Update enc) {
+
+}
+
+void OmxScreensaver::onKeyUpdate(OMXKeypadEvent e)
+{
+}
+
+void OmxScreensaver::updateLEDs()
+{
+    unsigned long playstepmillis = millis();
+	if (playstepmillis > nextStepTimeSS){ 
+		ssstep = ssstep % 16;
+		ssloop = ssloop % 16 ;
+	
+		int j = 26 - ssloop;
+		int i = ssstep + 11;
+
+		for (int z=1; z<11; z++){
+			strip.setPixelColor(z, 0);
+		}
+		if (!ssreverse) {
+			// turn off all leds
+			for (int x=0; x<16; x++){
+				if (i < j){
+					strip.setPixelColor(x+11, 0);
+				}
+				if (x+11 > j){
+					strip.setPixelColor(x+11, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+				}
+			}
+			strip.setPixelColor(i+1, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+		} else {
+			for (int y=0; y<16; y++){
+				if (i >= j){
+					strip.setPixelColor(y+11, 0);
+				}
+				if (y+11 < j){
+					strip.setPixelColor(y+11, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+				}
+			}
+			strip.setPixelColor(i+1, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+		}
+		ssstep++;
+		if (ssstep == 16){
+			ssloop++;
+		}
+		if (ssloop == 16){
+			ssreverse = !ssreverse;
+		}
+		nextStepTimeSS = nextStepTimeSS + sleepTick;
+
+        omxLeds.setDirty();
+	}
+}
+
+void OmxScreensaver::resetCounter()
+{
+    screenSaverCounter = 0;
+}

--- a/OMX-27-firmware/omx_screensaver.h
+++ b/OMX-27-firmware/omx_screensaver.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "omx_mode_interface.h"
+
+class OmxScreensaver : public OmxModeInterface
+{
+public:
+    OmxScreensaver(){}
+    ~OmxScreensaver(){}
+
+    void OnPotChanged(int potIndex, int potValue) override;
+
+    void updateLEDs() override;
+
+    void resetCounter();
+
+    void updateScreenSaverState();
+    bool shouldShowScreenSaver();
+
+    void onEncoderChanged(Encoder::Update enc) override;
+
+    void onEncoderButtonDown() override {};
+    void onEncoderButtonDownLong() override {};
+
+    void onKeyUpdate(OMXKeypadEvent e) override;
+    void onKeyHeldUpdate(OMXKeypadEvent e) {};
+private:
+    elapsedMillis screenSaverCounter = 0;
+    unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default? // 10000;  15000; //
+    int ssstep = 0;
+    int ssloop = 0;
+    volatile unsigned long nextStepTimeSS = 0;
+    bool ssreverse = false;
+
+    int sleepTick = 80;
+
+    bool screenSaverActive;
+};

--- a/OMX-27-firmware/omx_screensaver.h
+++ b/OMX-27-firmware/omx_screensaver.h
@@ -8,7 +8,7 @@ public:
     OmxScreensaver(){}
     ~OmxScreensaver(){}
 
-    void OnPotChanged(int potIndex, int potValue) override;
+    void onPotChanged(int potIndex, int potValue) override;
 
     void updateLEDs() override;
 

--- a/OMX-27-firmware/omx_screensaver.h
+++ b/OMX-27-firmware/omx_screensaver.h
@@ -24,6 +24,9 @@ public:
 
     void onKeyUpdate(OMXKeypadEvent e) override;
     void onKeyHeldUpdate(OMXKeypadEvent e) {};
+
+    void onDisplayUpdate() override;
+
 private:
     elapsedMillis screenSaverCounter = 0;
     unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default? // 10000;  15000; //

--- a/OMX-27-firmware/omx_util.cpp
+++ b/OMX-27-firmware/omx_util.cpp
@@ -3,19 +3,88 @@
 #include "omx_util.h"
 #include "consts.h"
 #include "MM.h"
+#include "colors.h"
+#include "omx_leds.h"
+#include "omx_disp.h"
 
-
-void OmxUtil::setup() {
-
+void OmxUtil::setup()
+{
 }
 
-
-// Pots
-void OmxUtil::sendPots(int val, int channel){
+void OmxUtil::sendPots(int val, int channel)
+{
     MM::sendControlChange(pots[potSettings.potbank][val], potSettings.analogValues[val], channel);
     potSettings.potCC = pots[potSettings.potbank][val];
     potSettings.potVal = potSettings.analogValues[val];
     potSettings.potValues[val] = potSettings.potVal;
+}
+
+void OmxUtil::cvNoteOn(int notenum)
+{
+    if (notenum >= midiLowestNote && notenum < midiHightestNote)
+    {
+        midiSettings.pitchCV = static_cast<int>(roundf((notenum - midiLowestNote) * stepsPerSemitone)); // map (adjnote, 36, 91, 0, 4080);
+        digitalWrite(CVGATE_PIN, HIGH);
+        analogWrite(CVPITCH_PIN, midiSettings.pitchCV);
+    }
+}
+void OmxUtil::cvNoteOff()
+{
+    digitalWrite(CVGATE_PIN, LOW);
+    //	analogWrite(CVPITCH_PIN, 0);
+}
+
+// #### Outbound MIDI Mode note on/off
+void OmxUtil::midiNoteOn(int notenum, int velocity, int channel)
+{
+    int adjnote = notes[notenum] + (midiSettings.octave * 12); // adjust key for octave range
+    midiSettings.rrChannel = (midiSettings.rrChannel % midiSettings.midiRRChannelCount) + 1;
+    int adjchan = midiSettings.rrChannel;
+
+    if (adjnote >= 0 && adjnote < 128)
+    {
+        midiSettings.midiLastNote = adjnote;
+
+        // keep track of adjusted note when pressed so that when key is released we send
+        // the correct note off message
+        midiSettings.midiKeyState[notenum] = adjnote;
+
+        // RoundRobin Setting?
+        if (midiSettings.midiRoundRobin)
+        {
+            adjchan = midiSettings.rrChannel + midiSettings.midiRRChannelOffset;
+        }
+        else
+        {
+            adjchan = channel;
+        }
+        midiSettings.midiChannelState[notenum] = adjchan;
+        MM::sendNoteOn(adjnote, velocity, adjchan);
+        // CV
+        cvNoteOn(adjnote);
+    }
+
+    strip.setPixelColor(notenum, MIDINOTEON); //  Set pixel's color (in RAM)
+    omxLeds.setDirty();
+    omxDisp.setDirty();
+}
+
+void OmxUtil::midiNoteOff(int notenum, int channel)
+{
+    // we use the key state captured at the time we pressed the key to send the correct note off message
+    int adjnote = midiSettings.midiKeyState[notenum];
+    int adjchan = midiSettings.midiChannelState[notenum];
+    if (adjnote >= 0 && adjnote < 128)
+    {
+        MM::sendNoteOff(adjnote, 0, adjchan);
+        // CV off
+        cvNoteOff();
+        midiSettings.midiKeyState[notenum] = -1;
+    }
+
+    strip.setPixelColor(notenum, LEDOFF);
+    omxLeds.setDirty();
+    omxDisp.setDirty();
 }
 
 OmxUtil omxUtil;

--- a/OMX-27-firmware/omx_util.cpp
+++ b/OMX-27-firmware/omx_util.cpp
@@ -5,9 +5,6 @@
 #include "MM.h"
 
 
-U8G2_FOR_ADAFRUIT_GFX u8g2_display;
-
-
 void OmxUtil::setup() {
 
 }
@@ -15,10 +12,10 @@ void OmxUtil::setup() {
 
 // Pots
 void OmxUtil::sendPots(int val, int channel){
-    MM::sendControlChange(pots[potbank][val], analogValues[val], channel);
-    potCC = pots[potbank][val];
-    potVal = analogValues[val];
-    potValues[val] = potVal;
+    MM::sendControlChange(pots[potSettings.potbank][val], potSettings.analogValues[val], channel);
+    potSettings.potCC = pots[potSettings.potbank][val];
+    potSettings.potVal = potSettings.analogValues[val];
+    potSettings.potValues[val] = potSettings.potVal;
 }
 
-OmxUtil omxutil;
+OmxUtil omxUtil;

--- a/OMX-27-firmware/omx_util.cpp
+++ b/OMX-27-firmware/omx_util.cpp
@@ -1,0 +1,24 @@
+#include <U8g2_for_Adafruit_GFX.h>
+
+#include "omx_util.h"
+#include "consts.h"
+#include "MM.h"
+
+
+U8G2_FOR_ADAFRUIT_GFX u8g2_display;
+
+
+void OmxUtil::setup() {
+
+}
+
+
+// Pots
+void OmxUtil::sendPots(int val, int channel){
+    MM::sendControlChange(pots[potbank][val], analogValues[val], channel);
+    potCC = pots[potbank][val];
+    potVal = analogValues[val];
+    potValues[val] = potVal;
+}
+
+OmxUtil omxutil;

--- a/OMX-27-firmware/omx_util.h
+++ b/OMX-27-firmware/omx_util.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "config.h"
 
+
+
 class OmxUtil
 {
 public:
@@ -9,6 +11,12 @@ public:
     void setup();
 
     void sendPots(int val, int channel);
+
+    // #### Clocks, might want to put in own class
+    void advanceClock(Micros advance);
+    void advanceSteps(Micros advance);
+    void setGlobalSwing(int swng_amt);
+    void resetClocks();
 
     // #### Outbound CV note on/off
     void cvNoteOn(int notenum);

--- a/OMX-27-firmware/omx_util.h
+++ b/OMX-27-firmware/omx_util.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "config.h"
+
+class OmxUtil
+{
+public:
+    OmxUtil(){
+        potCC = pots[potbank][0];
+    }
+
+    void setup();
+
+    void sendPots(int val, int channel);
+
+    void setSubmode(int submode);
+
+private:
+    int potbank = 0;
+    int analogValues[5] = {0,0,0,0,0};		// default values
+    int potValues[5] = {0,0,0,0,0};
+    int potCC = pots[potbank][0];
+    int potVal = analogValues[0];
+};
+
+extern OmxUtil omxutil;

--- a/OMX-27-firmware/omx_util.h
+++ b/OMX-27-firmware/omx_util.h
@@ -4,12 +4,19 @@
 class OmxUtil
 {
 public:
-    OmxUtil(){}
+    OmxUtil() {}
 
     void setup();
 
     void sendPots(int val, int channel);
 
+    // #### Outbound CV note on/off
+    void cvNoteOn(int notenum);
+    void cvNoteOff();
+
+    // #### Outbound MIDI note on/off
+    void midiNoteOn(int notenum, int velocity, int channel);
+    void midiNoteOff(int notenum, int channel);
 
 private:
     // int potbank = 0;

--- a/OMX-27-firmware/omx_util.h
+++ b/OMX-27-firmware/omx_util.h
@@ -4,22 +4,19 @@
 class OmxUtil
 {
 public:
-    OmxUtil(){
-        potCC = pots[potbank][0];
-    }
+    OmxUtil(){}
 
     void setup();
 
     void sendPots(int val, int channel);
 
-    void setSubmode(int submode);
 
 private:
-    int potbank = 0;
-    int analogValues[5] = {0,0,0,0,0};		// default values
-    int potValues[5] = {0,0,0,0,0};
-    int potCC = pots[potbank][0];
-    int potVal = analogValues[0];
+    // int potbank = 0;
+    // int analogValues[5] = {0,0,0,0,0};		// default values
+    // int potValues[5] = {0,0,0,0,0};
+    // int potCC = pots[potbank][0];
+    // int potVal = analogValues[0];
 };
 
-extern OmxUtil omxutil;
+extern OmxUtil omxUtil;

--- a/OMX-27-firmware/sequencer.cpp
+++ b/OMX-27-firmware/sequencer.cpp
@@ -35,7 +35,7 @@ extern SequencerState sequencer;
 // extern int defaultVelocity;
 
 // funcs in main ino
-extern void show_current_step(int patternNum);
+// extern void show_current_step(int patternNum);
 
 // extern StepNote* getSelectedStep();
 
@@ -389,18 +389,20 @@ void doStepS1()
 						}
 					}
 				}
-				if (j == sequencer.playingPattern)
-				{ // only show selected pattern
-					show_current_step(sequencer.playingPattern);
-				}
+				// No need to have this function call in here. 
+				// Can put into omx_mode_sequencer and remove extern function
+				// if (j == sequencer.playingPattern)
+				// { // only show selected pattern
+				// 	show_current_step(sequencer.playingPattern);
+				// }
 				new_step_ahead(j);
 			}
 		}
 	}
-	else
-	{
-		show_current_step(sequencer.playingPattern);
-	}
+	// else
+	// {
+	// 	// show_current_step(sequencer.playingPattern);
+	// }
 }
 
 void doStepS2()
@@ -443,18 +445,18 @@ void doStepS2()
 					}
 				}
 				//						show_current_step(playingPattern);
-				if (j == sequencer.playingPattern)
-				{ // only show selected pattern
-					show_current_step(sequencer.playingPattern);
-				}
+				// if (j == sequencer.playingPattern)
+				// { // only show selected pattern
+				// 	show_current_step(sequencer.playingPattern);
+				// }
 				new_step_ahead(j);
 			}
 		}
 	}
-	else
-	{
-		show_current_step(sequencer.playingPattern);
-	}
+	// else
+	// {
+	// 	show_current_step(sequencer.playingPattern);
+	// }
 }
 
 // TODO: move up to other sequencer stuff

--- a/OMX-27-firmware/sequencer.cpp
+++ b/OMX-27-firmware/sequencer.cpp
@@ -719,3 +719,6 @@ void pastePattern(int patternNum){
 	auto pattern = sequencer.getPattern(patternNum);
 	memcpy(&pattern->steps, &copyPatternBuffer, NUM_STEPS * sizeof(StepNote));
 }
+
+// global sequencer shared state
+SequencerState sequencer = defaultSequencer();

--- a/OMX-27-firmware/sequencer.cpp
+++ b/OMX-27-firmware/sequencer.cpp
@@ -36,9 +36,6 @@ extern SequencerState sequencer;
 
 // funcs in main ino
 extern void show_current_step(int patternNum);
-// extern void cvNoteOn(int notenum);
-// extern void cvNoteOff();
-
 
 // extern StepNote* getSelectedStep();
 

--- a/OMX-27-firmware/sequencer.cpp
+++ b/OMX-27-firmware/sequencer.cpp
@@ -6,36 +6,41 @@
 #include "colors.h"
 #include "MM.h"
 #include "noteoffs.h"
+#include "omx_disp.h"
+#include "omx_leds.h"
+#include "omx_util.h"
 
 // globals in main ino
 extern SequencerState sequencer;
-extern SysSettings sysSettings;
+// extern SysSettings sysSettings;
 
 // extern int midiChannel;
-extern int selectedStep;
+// extern int omxSeqselectedStep;
 
-extern Adafruit_NeoPixel strip;
+// extern Adafruit_NeoPixel strip;
 
-extern volatile unsigned long step_micros;
-extern volatile unsigned long noteon_micros;
-extern volatile unsigned long noteoff_micros;
-extern volatile unsigned long ppqInterval;
+// extern volatile unsigned long omxseqstep_micros;
+// extern volatile unsigned long seqConfig.noteon_micros;
+// extern volatile unsigned long noteoff_micros;
+// extern volatile unsigned long ppqInterval;
 
-extern int octave;			// default C4 is 0 - range is -4 to +5
-extern int midiKeyState[27];
-extern bool dirtyPixels;
-extern bool dirtyDisplay;
-extern PendingNoteOffs pendingNoteOffs;
-extern int potbank;
-extern int potValues[];
-extern int prevPlock[];
-extern int defaultVelocity;
+// extern int octave;			// default C4 is 0 - range is -4 to +5
+// extern int midiKeyState[27];
+// extern bool dirtyPixels;
+// extern bool dirtyDisplay;
+// extern PendingNoteOffs pendingNoteOffs; // in noteoffs.h
+// extern int potbank;
+// extern int potValues[];
+// extern int prevPlock[];
+// extern int defaultVelocity;
 
 // funcs in main ino
 extern void show_current_step(int patternNum);
-extern void cvNoteOn(int notenum);
-extern void cvNoteOff();
-extern StepNote* getSelectedStep();
+// extern void cvNoteOn(int notenum);
+// extern void cvNoteOff();
+
+
+// extern StepNote* getSelectedStep();
 
 // globals from sequencer.h
 uint8_t lastNote[NUM_PATTERNS][NUM_STEPS] = {
@@ -156,7 +161,7 @@ int serializedPatternSize(bool eeprom) {
 }
 
 StepNote* getSelectedStep() {
-	return &sequencer.getCurrentPattern()->steps[selectedStep];
+	return &sequencer.getCurrentPattern()->steps[seqConfig.selectedStep];
 }
 
 void step_ahead() {
@@ -349,93 +354,109 @@ void step_off(int patternNum, int position){
 //	digitalWrite(CVGATE_PIN, LOW);
 }
 
-void doStep() {
-// // probability test
+void doStepS1()
+{
+	// // probability test
 	bool testProb = probResult(sequencer.getCurrentPattern()->steps[sequencer.seqPos[sequencer.playingPattern]].prob);
 
-	switch(sysSettings.omxMode){
-		case MODE_S1:
-			if(sequencer.playing) {
-				unsigned long playstepmicros = micros();
+	if (sequencer.playing)
+	{
+		unsigned long playstepmicros = micros();
 
-				for (int j=0; j<NUM_PATTERNS; j++){  // check all patterns for notes to play in time
-					// CLOCK PER PATTERN BASED APPROACH
-					auto pattern = sequencer.getPattern(j);
+		for (int j = 0; j < NUM_PATTERNS; j++)
+		{ // check all patterns for notes to play in time
+			// CLOCK PER PATTERN BASED APPROACH
+			auto pattern = sequencer.getPattern(j);
 
-					// TODO: refactor timePerPattern stuff into sequencer.h
+			// TODO: refactor timePerPattern stuff into sequencer.h
 
-					if (playstepmicros >= sequencer.timePerPattern[j].nextStepTimeP) {
+			if (playstepmicros >= sequencer.timePerPattern[j].nextStepTimeP)
+			{
 
-						seqReset(); // check for seqReset
-						sequencer.timePerPattern[j].lastStepTimeP = sequencer.timePerPattern[j].nextStepTimeP;
-						sequencer.timePerPattern[j].nextStepTimeP += (step_micros)*( multValues[sequencer.getPattern(j)->clockDivMultP] ); // calc step based on rate
+				seqReset(); // check for seqReset
+				sequencer.timePerPattern[j].lastStepTimeP = sequencer.timePerPattern[j].nextStepTimeP;
+				sequencer.timePerPattern[j].nextStepTimeP += (clockConfig.step_micros) * (multValues[sequencer.getPattern(j)->clockDivMultP]); // calc step based on rate
 
-						sequencer.timePerPattern[j].lastPosP = (sequencer.seqPos[j] + 15) % 16;
-						if (lastNote[j][sequencer.timePerPattern[j].lastPosP] > 0) {
-							step_off(j, sequencer.timePerPattern[j].lastPosP);
+				sequencer.timePerPattern[j].lastPosP = (sequencer.seqPos[j] + 15) % 16;
+				if (lastNote[j][sequencer.timePerPattern[j].lastPosP] > 0)
+				{
+					step_off(j, sequencer.timePerPattern[j].lastPosP);
+				}
+				if (testProb)
+				{
+					if (evaluate_AB(pattern->steps[sequencer.seqPos[j]].condition, j))
+					{
+						if (j == sequencer.playingPattern)
+						{
+							playNote(j);
 						}
-						if (testProb){
-							if (evaluate_AB(pattern->steps[sequencer.seqPos[j]].condition, j)){
-								if (j == sequencer.playingPattern){
-									playNote(j);
-								}
-							}
-						}
-						if (j == sequencer.playingPattern){ // only show selected pattern
-							show_current_step(sequencer.playingPattern);
-						}
-						new_step_ahead(j);
 					}
 				}
-			} else {
-				show_current_step(sequencer.playingPattern);
+				if (j == sequencer.playingPattern)
+				{ // only show selected pattern
+					show_current_step(sequencer.playingPattern);
+				}
+				new_step_ahead(j);
 			}
-			break;
+		}
+	}
+	else
+	{
+		show_current_step(sequencer.playingPattern);
+	}
+}
 
-		case MODE_S2:
-			if(sequencer.playing) {
-				unsigned long playstepmicros = micros();
+void doStepS2()
+{
+	// // probability test
+	bool testProb = probResult(sequencer.getCurrentPattern()->steps[sequencer.seqPos[sequencer.playingPattern]].prob);
 
-				for (int j=0; j<NUM_PATTERNS; j++){  // check all patterns for notes to play in time
-					// CLOCK PER PATTERN BASED APPROACH
-					auto pattern = sequencer.getPattern(j);
+	if (sequencer.playing)
+	{
+		unsigned long playstepmicros = micros();
 
-					// TODO: refactor timePerPattern stuff into sequencer.h
+		for (int j = 0; j < NUM_PATTERNS; j++)
+		{ // check all patterns for notes to play in time
+			// CLOCK PER PATTERN BASED APPROACH
+			auto pattern = sequencer.getPattern(j);
 
-					if (playstepmicros >= sequencer.timePerPattern[j].nextStepTimeP) {
+			// TODO: refactor timePerPattern stuff into sequencer.h
 
-						seqReset(); // check for seqReset
-						sequencer.timePerPattern[j].lastStepTimeP = sequencer.timePerPattern[j].nextStepTimeP;
-						sequencer.timePerPattern[j].nextStepTimeP += (step_micros)*( multValues[sequencer.getPattern(j)->clockDivMultP] ); // calc step based on rate
+			if (playstepmicros >= sequencer.timePerPattern[j].nextStepTimeP)
+			{
 
-						// only play if not muted
-						if (!sequencer.getPattern(j)->mute) {
-							sequencer.timePerPattern[j].lastPosP = (sequencer.seqPos[j] + 15) % 16;
-							if (lastNote[j][sequencer.timePerPattern[j].lastPosP] > 0) {
-								step_off(j, sequencer.timePerPattern[j].lastPosP);
-							}
-							if (testProb){
-								if (evaluate_AB(pattern->steps[sequencer.seqPos[j]].condition, j)){
-									playNote(j);
-								}
-							}
+				seqReset(); // check for seqReset
+				sequencer.timePerPattern[j].lastStepTimeP = sequencer.timePerPattern[j].nextStepTimeP;
+				sequencer.timePerPattern[j].nextStepTimeP += (clockConfig.step_micros) * (multValues[sequencer.getPattern(j)->clockDivMultP]); // calc step based on rate
+
+				// only play if not muted
+				if (!sequencer.getPattern(j)->mute)
+				{
+					sequencer.timePerPattern[j].lastPosP = (sequencer.seqPos[j] + 15) % 16;
+					if (lastNote[j][sequencer.timePerPattern[j].lastPosP] > 0)
+					{
+						step_off(j, sequencer.timePerPattern[j].lastPosP);
+					}
+					if (testProb)
+					{
+						if (evaluate_AB(pattern->steps[sequencer.seqPos[j]].condition, j))
+						{
+							playNote(j);
 						}
-//						show_current_step(playingPattern);
-						if(j == sequencer.playingPattern){ // only show selected pattern
-							show_current_step(sequencer.playingPattern);
-						}
-						new_step_ahead(j);
 					}
 				}
-
-
-			} else {
-				show_current_step(sequencer.playingPattern);
+				//						show_current_step(playingPattern);
+				if (j == sequencer.playingPattern)
+				{ // only show selected pattern
+					show_current_step(sequencer.playingPattern);
+				}
+				new_step_ahead(j);
 			}
-			break;
-
-		default:
-			break;
+		}
+	}
+	else
+	{
+		show_current_step(sequencer.playingPattern);
 	}
 }
 
@@ -443,40 +464,40 @@ void doStep() {
 
 // #### SEQ Mode note on/off
 void seqNoteOn(int notenum, int velocity, int patternNum) {
-	int adjnote = notes[notenum] + (octave * 12); // adjust key for octave range
+	int adjnote = notes[notenum] + (midiSettings.octave * 12); // adjust key for octave range
 	if (adjnote>=0 && adjnote <128){
 		lastNote[patternNum][sequencer.seqPos[patternNum]] = adjnote;
 		MM::sendNoteOn(adjnote, velocity, sequencer.getPatternChannel(sequencer.playingPattern));
 
 		// keep track of adjusted note when pressed so that when key is released we send
 		// the correct note off message
-		midiKeyState[notenum] = adjnote;
+		midiSettings.midiKeyState[notenum] = adjnote;
 
 		// CV
 		if (sequencer.getCurrentPattern()->sendCV) {
-			cvNoteOn(adjnote);
+			omxUtil.cvNoteOn(adjnote);
 		}
 	}
 
 	strip.setPixelColor(notenum, MIDINOTEON);         //  Set pixel's color (in RAM)
-	dirtyPixels = true;
-	dirtyDisplay = true;
+	omxDisp.setDirty();
+	omxLeds.setDirty();
 }
 
 void seqNoteOff(int notenum, int patternNum){
 	// we use the key state captured at the time we pressed the key to send the correct note off message
-	int adjnote = midiKeyState[notenum];
+	int adjnote = midiSettings.midiKeyState[notenum];
 	if (adjnote>=0 && adjnote <128){
 		MM::sendNoteOff(adjnote, 0, sequencer.getPatternChannel(sequencer.playingPattern));
 		// CV off
 		if (sequencer.getCurrentPattern()->sendCV){
-			cvNoteOff();
+			omxUtil.cvNoteOff();
 		}
 	}
 
 	strip.setPixelColor(notenum, LEDOFF);
-	dirtyPixels = true;
-	dirtyDisplay = true;
+	omxDisp.setDirty();
+	omxLeds.setDirty();
 }
 
 
@@ -549,40 +570,40 @@ void playNote(int patternNum) {
 	if (steps[sequencer.seqPos[patternNum]].trig == TRIGTYPE_PLAY) {
 		sequencer.seq_velocity = steps[sequencer.seqPos[patternNum]].vel;
 
-		noteoff_micros = micros() + (steps[sequencer.seqPos[patternNum]].len + 1) * step_micros;
-		pendingNoteOffs.insert(steps[sequencer.seqPos[patternNum]].note, sequencer.getPatternChannel(patternNum), noteoff_micros, sendnoteCV);
+		seqConfig.noteoff_micros = micros() + (steps[sequencer.seqPos[patternNum]].len + 1) * clockConfig.step_micros;
+		pendingNoteOffs.insert(steps[sequencer.seqPos[patternNum]].note, sequencer.getPatternChannel(patternNum), seqConfig.noteoff_micros, sendnoteCV);
 
 		if (sequencer.seqPos[patternNum] % 2 == 0){
 
 			if (pattern->swing < 99){
-				noteon_micros = micros() + ((ppqInterval * multValues[pattern->clockDivMultP])/(PPQ / 24) * pattern->swing); // full range swing
-			// 	Serial.println((ppqInterval * multValues[settings->clockDivMultP])/(PPQ / 24) * settings->swing);
+				seqConfig.noteon_micros = micros() + ((clockConfig.ppqInterval * multValues[pattern->clockDivMultP])/(PPQ / 24) * pattern->swing); // full range swing
+			// 	Serial.println((clockConfig.ppqInterval * multValues[settings->clockDivMultP])/(PPQ / 24) * settings->swing);
 			// } else if ((settings->swing > 50) && (settings->swing < 99)){
 			//    noteon_micros = micros() + ((step_micros * multValues[settings->clockDivMultP]) * ((settings->swing - 50)* .01) ); // late swing
 			//    Serial.println(((step_micros * multValues[settings->clockDivMultP]) * ((settings->swing - 50)* .01) ));
 			} else if (pattern->swing == 99){ // random drunken swing
 				rnd_swing = rand() % 95 + 1; // rand 1 - 95 // randomly apply swing value
-				noteon_micros = micros() + ((ppqInterval * multValues[pattern->clockDivMultP])/(PPQ / 24) * rnd_swing);
+				seqConfig.noteon_micros = micros() + ((clockConfig.ppqInterval * multValues[pattern->clockDivMultP])/(PPQ / 24) * rnd_swing);
 			}
 
 		} else {
-			noteon_micros = micros();
+			seqConfig.noteon_micros = micros();
 		}
 
 		// Queue note-on
-		pendingNoteOns.insert(steps[sequencer.seqPos[patternNum]].note, sequencer.seq_velocity, sequencer.getPatternChannel(patternNum), noteon_micros, sendnoteCV);
+		pendingNoteOns.insert(steps[sequencer.seqPos[patternNum]].note, sequencer.seq_velocity, sequencer.getPatternChannel(patternNum), seqConfig.noteon_micros, sendnoteCV);
 
 		// {notenum, vel, notelen, step_type, {p1,p2,p3,p4}, prob}
 		// send param locks
 		for (int q=0; q<4; q++){
 			int tempCC = steps[sequencer.seqPos[patternNum]].params[q];
 			if (tempCC > -1) {
-				MM::sendControlChange(pots[potbank][q],tempCC,sequencer.getPatternChannel(patternNum));
-				prevPlock[q] = tempCC;
-			} else if (prevPlock[q] != potValues[q]) {
-				//if (tempCC != prevPlock[q]) {
-				MM::sendControlChange(pots[potbank][q],potValues[q],sequencer.getPatternChannel(patternNum));
-				prevPlock[q] = potValues[q];
+				MM::sendControlChange(pots[potSettings.potbank][q],tempCC,sequencer.getPatternChannel(patternNum));
+				seqConfig.prevPlock[q] = tempCC;
+			} else if (seqConfig.prevPlock[q] != potSettings.potValues[q]) {
+				//if (tempCC != seqConfig.prevPlock[q]) {
+				MM::sendControlChange(pots[potSettings.potbank][q],potSettings.potValues[q],sequencer.getPatternChannel(patternNum));
+				seqConfig.prevPlock[q] = potSettings.potValues[q];
 			}
 		}
 		lastNote[patternNum][sequencer.seqPos[patternNum]] = steps[sequencer.seqPos[patternNum]].note;
@@ -691,7 +712,7 @@ void clearPattern(int patternNum){
 	for (int i = 0; i < NUM_STEPS; i++){
 		// {notenum,vel,len,stepType,{p1,p2,p3,p4,p5}}
 		steps[i].note = sequencer.patternDefaultNoteMap[patternNum];
-		steps[i].vel = defaultVelocity;
+		steps[i].vel = midiSettings.defaultVelocity;
 		steps[i].len = 0;
 		steps[i].stepType = STEPTYPE_NONE;
 		steps[i].params[0] = -1;

--- a/OMX-27-firmware/sequencer.h
+++ b/OMX-27-firmware/sequencer.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <Arduino.h>
+#include "config.h"
 
 #define NUM_PATTERNS 8
 #define NUM_STEPS 64
 #define NUM_STEPKEYS 16
-
-using Micros = unsigned long;    // for tracking time per pattern
 
 struct TimePerPattern {
 	Micros lastProcessTimeP : 32;
@@ -126,7 +125,9 @@ SequencerState defaultSequencer();
 int serializedPatternSize(bool eeprom);
 
 StepNote* getSelectedStep();
-void doStep();
+void doStepS1();
+void doStepS2();
+
 void transposeSeq(int patternNum, int amt);
 int getPatternPage(int position);
 void rotatePattern(int patternNum, int rot);

--- a/OMX-27-firmware/sequencer.h
+++ b/OMX-27-firmware/sequencer.h
@@ -153,3 +153,6 @@ void resetPatternDefaults(int patternNum);
 void copyPattern(int patternNum);
 void pastePattern(int patternNum);
 void clearPattern(int patternNum);
+
+// global sequencer shared state
+extern SequencerState sequencer;


### PR DESCRIPTION
This PR splits up the functionality contained in OMX-27-firmware.ino into several classes. 

The goal of this refactor is to organize and structure the code to make it easier to add new features and modes and increase readability. 

No additional features have been added and functionality is the same as main. 

Each mode now has it's own class where it's logic is defined. The base abstract class OmxModeInterface is used to define an interface for an OMX Mode. The sequencer and midi mode logic was split into their own classes: OmxModeSequencer and OmxModeMidiKeyboard. Since the difference between S1 and & S2 modes is minimal, both modes use the same class and a bool is set depending on the mode. The difference between OM and MI modes is also minimal, so a bool is used to set the Midi mode to Organelle mode. 

Big switch logic was removed and replaced with function calls to the activeOmxMode which points at the class of the current mode. The function changeOmxMode() handles switching the pointer. 

Since lots of variables are shared between the sequencer and midi modes, I've moved these into global structs in config.h so they can be easily accessed from any of the modes. 

Specific shared code for updating the LEDs, Display, Midi, CV were moved into OmxDisp, OmxLeds, and OmxUtil. These each declare a global instance of themselves in their headers. 

The screensaver code was also moved into it's own class OmxScreensaver

The Midi modes and Sequencer modes can still be cleaned up quite a lot has they have some very long functions, but at least they are self contained so all their logic is in one place. 

Please pull branch, build, test and let me know any issues before merging. Thanks. 

