### PR TITLE
Fix potentiometers issue for Euclidean and Grids

### DIFF
--- a/OMX-27-firmware/src/omx_mode_euclidean.cpp
+++ b/OMX-27-firmware/src/omx_mode_euclidean.cpp
@@ -9,6 +9,7 @@
 #include "noteoffs.h"
 #include "MM.h"
 #include "logic_util.h"
+#include "consts.h"
 
 using namespace euclidean;
 
@@ -360,7 +361,14 @@ void OmxModeEuclidean::onPotChanged(int potIndex, int prevValue, int newValue, i
     {
         // Serial.println("Edit Mode");
 
-        if (analogDelta < 3)
+        // delta is way smaller on T4 - what to do?? Check OMX-27-firmware.ino 223
+        #if T4
+            int minAnalogDelta = 1;
+        #else
+            int minAnalogDelta = 3;
+        #endif
+
+        if (analogDelta < minAnalogDelta)
             return;
 
 

--- a/OMX-27-firmware/src/omx_mode_grids.cpp
+++ b/OMX-27-firmware/src/omx_mode_grids.cpp
@@ -5,6 +5,7 @@
 #include "omx_leds.h"
 // #include "sequencer.h"
 #include "noteoffs.h"
+#include "consts.h"
 
 using namespace grids;
 


### PR DESCRIPTION
`#include "consts.h"` was missed in grids so deltaTheshold was always 6.
I added a similar workaround for Euclidean, but I think we should improve it later