### PR TITLE
screensaver update to use current pot value to set color

### DIFF
--- a/OMX-27-firmware/src/omx_screensaver.cpp
+++ b/OMX-27-firmware/src/omx_screensaver.cpp
@@ -1,34 +1,43 @@
-#include "omx_screensaver.h"
-#include "consts.h"
-#include "config.h"
-#include "omx_util.h"
-#include "omx_disp.h"
-#include "omx_leds.h"
+#include "./omx_screensaver.h"
+#include "../consts/consts.h"
+#include "../config.h"
+#include "../utils/omx_util.h"
+#include "../hardware/omx_disp.h"
+#include "../hardware/omx_leds.h"
+
+void OmxScreensaver::setScreenSaverColor()
+{
+	colorConfig.screensaverColor = map(potSettings.analog[4]->getValue(), potMinVal, potMaxVal, 0, 32764);
+}
 
 void OmxScreensaver::onPotChanged(int potIndex, int prevValue, int newValue, int analogDelta)
 {
-//     colorConfig.screensaverColor = potSettings.analog[4]->getValue() * 4; // value is 0-32764 for strip.ColorHSV
-	int pot_temp = map(potSettings.analog[4]->getValue(), potMinVal, potMaxVal, 0, 32764);
-    colorConfig.screensaverColor = pot_temp; // value is 0-32764 for strip.ColorHSV
+	//     colorConfig.screensaverColor = potSettings.analog[4]->getValue() * 4; // value is 0-32764 for strip.ColorHSV
+	setScreenSaverColor();
 
-    // reset screensaver
-    if (potSettings.analog[0]->hasChanged() || potSettings.analog[1]->hasChanged() || potSettings.analog[2]->hasChanged() || potSettings.analog[3]->hasChanged())
-    {
-        screenSaverCounter = 0;
-    }
+	// reset screensaver
+	if (potSettings.analog[0]->hasChanged() || potSettings.analog[1]->hasChanged() || potSettings.analog[2]->hasChanged() || potSettings.analog[3]->hasChanged())
+	{
+		screenSaverCounter = 0;
+	}
 }
 
 void OmxScreensaver::updateScreenSaverState()
 {
-    if (screenSaverCounter > screensaverInterval ){
+	if (screenSaverCounter > screensaverInterval)
+	{
 		screenSaverActive = true;
-	} else if (screenSaverCounter < 10){
+	}
+	else if (screenSaverCounter < 10)
+	{
 		ssstep = 0;
 		ssloop = 0;
-//		setAllLEDS(0,0,0);
+		//		setAllLEDS(0,0,0);
 		screenSaverActive = false;
 		nextStepTimeSS = millis();
-	} else {
+	}
+	else
+	{
 		screenSaverActive = false;
 		nextStepTimeSS = millis();
 	}
@@ -36,79 +45,94 @@ void OmxScreensaver::updateScreenSaverState()
 
 bool OmxScreensaver::shouldShowScreenSaver()
 {
-    return screenSaverActive;
+	setScreenSaverColor();
+	return screenSaverActive;
 }
 
-void OmxScreensaver::onEncoderChanged(Encoder::Update enc) {
-
+void OmxScreensaver::onEncoderChanged(Encoder::Update enc)
+{
 }
 
 void OmxScreensaver::onKeyUpdate(OMXKeypadEvent e)
 {
 }
 
+void OmxScreensaver::onDisplayUpdate()
+{
+	updateLEDs();
+	omxDisp.clearDisplay();
+}
+void OmxScreensaver::resetCounter()
+{
+	screenSaverCounter = 0;
+}
 void OmxScreensaver::updateLEDs()
 {
-    unsigned long playstepmillis = millis();
-	if (playstepmillis > nextStepTimeSS){
+	unsigned long playstepmillis = millis();
+	if (playstepmillis > nextStepTimeSS)
+	{
 		ssstep = ssstep % 16;
-		ssloop = ssloop % 16 ;
+		ssloop = ssloop % 16;
 
 		int j = 26 - ssloop;
 		int i = ssstep + 11;
 
-		for (int z=1; z<11; z++){
+		for (int z = 1; z < 11; z++)
+		{
 			strip.setPixelColor(z, 0);
 		}
-		if (colorConfig.screensaverColor != 0) {
-			if (!ssreverse) {
+		if (colorConfig.screensaverColor != 0)
+		{
+			if (!ssreverse)
+			{
 				// turn off all leds
-				for (int x=0; x<16; x++){
-					if (i < j){
-						strip.setPixelColor(x+11, 0);
+				for (int x = 0; x < 16; x++)
+				{
+					if (i < j)
+					{
+						strip.setPixelColor(x + 11, 0);
 					}
-					if (x+11 > j){
-						strip.setPixelColor(x+11, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
-					}
-				}
-				strip.setPixelColor(i+1, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
-			} else {
-				for (int y=0; y<16; y++){
-					if (i >= j){
-						strip.setPixelColor(y+11, 0);
-					}
-					if (y+11 < j){
-						strip.setPixelColor(y+11, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+					if (x + 11 > j)
+					{
+						strip.setPixelColor(x + 11, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
 					}
 				}
-				strip.setPixelColor(i+1, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+				strip.setPixelColor(i + 1, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
 			}
-		} else {
-			for (int w=0; w<27; w++){
+			else
+			{
+				for (int y = 0; y < 16; y++)
+				{
+					if (i >= j)
+					{
+						strip.setPixelColor(y + 11, 0);
+					}
+					if (y + 11 < j)
+					{
+						strip.setPixelColor(y + 11, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+					}
+				}
+				strip.setPixelColor(i + 1, strip.gamma32(strip.ColorHSV(colorConfig.screensaverColor)));
+			}
+		}
+		else
+		{
+			for (int w = 0; w < 27; w++)
+			{
 				strip.setPixelColor(w, 0);
 			}
 		}
 		ssstep++;
-		if (ssstep == 16){
+		if (ssstep == 16)
+		{
 			ssloop++;
 		}
-		if (ssloop == 16){
+		if (ssloop == 16)
+		{
 			ssreverse = !ssreverse;
 		}
 		nextStepTimeSS = nextStepTimeSS + sleepTick;
 
-        omxLeds.setDirty();
+		omxLeds.setDirty();
 	}
 }
-
-void OmxScreensaver::resetCounter()
-{
-    screenSaverCounter = 0;
-}
-
-void OmxScreensaver::onDisplayUpdate()
-{
-    updateLEDs();
-	omxDisp.clearDisplay();
-}
-

--- a/OMX-27-firmware/src/omx_screensaver.h
+++ b/OMX-27-firmware/src/omx_screensaver.h
@@ -1,41 +1,42 @@
 #pragma once
 
-#include "omx_mode_interface.h"
+#include "./omx_mode_interface.h"
 
 class OmxScreensaver : public OmxModeInterface
 {
 public:
-    OmxScreensaver(){}
-    ~OmxScreensaver(){}
+	OmxScreensaver() {}
+	~OmxScreensaver() {}
 
-    void onPotChanged(int potIndex, int prevValue, int newValue, int analogDelta) override;
+	void onPotChanged(int potIndex, int prevValue, int newValue, int analogDelta) override;
 
-    void updateLEDs() override;
+	void updateLEDs() override;
 
-    void resetCounter();
+	void resetCounter();
 
-    void updateScreenSaverState();
-    bool shouldShowScreenSaver();
+	void updateScreenSaverState();
+	bool shouldShowScreenSaver();
 
-    void onEncoderChanged(Encoder::Update enc) override;
+	void onEncoderChanged(Encoder::Update enc) override;
 
-    void onEncoderButtonDown() override {};
-    void onEncoderButtonDownLong() override {};
+	void onEncoderButtonDown() override{};
+	void onEncoderButtonDownLong() override{};
 
-    void onKeyUpdate(OMXKeypadEvent e) override;
-    void onKeyHeldUpdate(OMXKeypadEvent e) {};
+	void onKeyUpdate(OMXKeypadEvent e) override;
+	void onKeyHeldUpdate(OMXKeypadEvent e){};
 
-    void onDisplayUpdate() override;
+	void onDisplayUpdate() override;
 
 private:
-    elapsedMillis screenSaverCounter = 0;
-    unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default? // 10000;  15000; //
-    int ssstep = 0;
-    int ssloop = 0;
-    volatile unsigned long nextStepTimeSS = 0;
-    bool ssreverse = false;
+	void setScreenSaverColor();
+	elapsedMillis screenSaverCounter = 0;
+	unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default? // 10000;  15000; //
+	int ssstep = 0;
+	int ssloop = 0;
+	volatile unsigned long nextStepTimeSS = 0;
+	bool ssreverse = false;
 
-    int sleepTick = 80;
+	int sleepTick = 80;
 
-    bool screenSaverActive;
+	bool screenSaverActive;
 };


### PR DESCRIPTION
I wasn't happy with the way the screensaver always defaults to `red` after a power-cycle.

This change instead uses the current value of the screensaver color pot (pot 5) to set the color of the screensaver when it is activated.

This allows for a bit more dynacism in the screensaver, because that pot's value might be different each time the screensaver gets called, and if not, it's the same color as set previously.

I tried to make the value save alongside everything else, but that wasn't working so I went for this method, and ended up enjoying this more.