### PR TITLE
Fix possible Scale Corruption in Midi Mode; disallow Lock and Group changes when scale is off

### DIFF
--- a/OMX-27-firmware/src/config.h
+++ b/OMX-27-firmware/src/config.h
@@ -281,7 +281,9 @@ struct ScaleConfig
 	int scaleRoot = 0;
 	int scalePattern = -1;
 	bool lockScale = false; // If Scale is locked you will be unable to play notes out of the scale.
+	bool lockedState = false; // for holding previous scale lock state
 	bool group16 = false;	// If group16 is active, all notes in scale will be grouped into lower 16 notes.
+	bool groupedState = false;	// for holding previous group16 state
 	bool scaleSelectHold;
 	bool showScaleInSeq = false;
 };

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
@@ -394,14 +394,39 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
 				omxDisp.displayMessage(musicScale->getScaleName(scaleConfig.scalePattern));
 				musicScale->calculateScale(scaleConfig.scaleRoot, scaleConfig.scalePattern);
 			}
+
+			if (scaleConfig.scalePattern == -1)
+			{ // record locked and grouped states, then set the current lockScale and group16 to off
+				if (prevPat != -1)
+				{
+					scaleConfig.lockedState = scaleConfig.lockScale;
+					scaleConfig.groupedState = scaleConfig.group16;
+				}
+				scaleConfig.lockScale = 0;
+				scaleConfig.group16 = 0;
+			}
+			else
+			{ // restore locked and grouped states if the scale was previously set to off
+				if (prevPat == -1)
+				{
+					scaleConfig.lockScale = scaleConfig.lockedState;
+					scaleConfig.group16 = scaleConfig.groupedState;
+				}
+			}
 		}
 		if (selParam == 3)
 		{
-			scaleConfig.lockScale = constrain(scaleConfig.lockScale + amt, 0, 1);
+			if (scaleConfig.scalePattern != -1)
+			{
+				scaleConfig.lockScale = constrain(scaleConfig.lockScale + amt, 0, 1);
+			}
 		}
 		if (selParam == 4)
 		{
-			scaleConfig.group16 = constrain(scaleConfig.group16 + amt, 0, 1);
+			if (scaleConfig.scalePattern != -1)
+			{
+				scaleConfig.group16 = constrain(scaleConfig.group16 + amt, 0, 1);
+			}
 		}
 	}
 


### PR DESCRIPTION
# Issue

When in Midi mode, if the user sets the scale to `OFF` after using a different scale, but then turns lock scale  `ON`, the scale is set to a corrupted scale instead of the chromatic scale.

This leads to confusion, because none of the lights are lit up, signifying that the user should be able to play any note on the keyboard, but there are some notes that don't trigger, because the scale has become corrupted.

## STR

- Set Scale to something besides `OFF`
- Set Scale mode to `OFF`
- Set Scale Lock to `ON`
- Try to play notes on every button

Some notes won't trigger, despite the chromatic scale being selected

### This fix does two things when the Scale is set to `OFF` (-1)

1. When the Scale is set to `OFF` (aka chromatic scale), the current Lock and Group setting values are saved, and then both are set to `OFF`, as they are unneeded in the chromatic scale
2. When the Scale is set to anything besides `OFF`, the previous lock and group settings are restored!