### PR TITLE
Screensaver color depth fix - add missing colors to screensaver, plus an 'off' state

### DIFF
--- a/OMX-27-firmware/src/config.cpp
+++ b/OMX-27-firmware/src/config.cpp
@@ -55,9 +55,9 @@ int pots[NUM_CC_BANKS][NUM_CC_POTS] = {
 
 int potMinVal = 0;
 #if T4
-int potMaxVal = 1019; // T4 = 1019 // T3.2 = 8190;
+int potMaxVal = 1019; // T4 = 1019 // T3.2 = 8191;
 #else
-int potMaxVal = 8190; // T4 = 1019 // T3.2 = 8190;
+int potMaxVal = 8191; // T4 = 1019 // T3.2 = 8191;
 #endif
 
 const int gridh = 32;

--- a/OMX-27-firmware/src/modes/omx_screensaver.cpp
+++ b/OMX-27-firmware/src/modes/omx_screensaver.cpp
@@ -7,14 +7,16 @@
 
 void OmxScreensaver::setScreenSaverColor()
 {
-	colorConfig.screensaverColor = map(potSettings.analog[4]->getValue(), potMinVal, potMaxVal, 0, 32764);
+	colorConfig.screensaverColor = map(potSettings.analog[4]->getValue(), potMinVal, potMaxVal, 0, ssMaxColorDepth);
 }
 
 void OmxScreensaver::onPotChanged(int potIndex, int prevValue, int newValue, int analogDelta)
 {
-	//     colorConfig.screensaverColor = potSettings.analog[4]->getValue() * 4; // value is 0-32764 for strip.ColorHSV
-	setScreenSaverColor();
-
+	// set screensaver color with pot 4
+	if (potSettings.analog[4]->hasChanged())
+	{
+		setScreenSaverColor();
+	}
 	// reset screensaver
 	if (potSettings.analog[0]->hasChanged() || potSettings.analog[1]->hasChanged() || potSettings.analog[2]->hasChanged() || potSettings.analog[3]->hasChanged())
 	{
@@ -81,7 +83,7 @@ void OmxScreensaver::updateLEDs()
 		{
 			strip.setPixelColor(z, 0);
 		}
-		if (colorConfig.screensaverColor < 32639)
+		if (colorConfig.screensaverColor < ssMaxColorDepth)
 		{
 			if (!ssreverse)
 			{

--- a/OMX-27-firmware/src/modes/omx_screensaver.cpp
+++ b/OMX-27-firmware/src/modes/omx_screensaver.cpp
@@ -28,8 +28,12 @@ void OmxScreensaver::updateScreenSaverState()
 {
 	if (screenSaverCounter > screensaverInterval)
 	{
-		screenSaverActive = true;
-	}
+        if (!screenSaverActive)
+        {
+            screenSaverActive = true;
+            setScreenSaverColor();
+        }
+    }
 	else if (screenSaverCounter < 10)
 	{
 		ssstep = 0;
@@ -47,7 +51,6 @@ void OmxScreensaver::updateScreenSaverState()
 
 bool OmxScreensaver::shouldShowScreenSaver()
 {
-	setScreenSaverColor();
 	return screenSaverActive;
 }
 
@@ -64,10 +67,12 @@ void OmxScreensaver::onDisplayUpdate()
 	updateLEDs();
 	omxDisp.clearDisplay();
 }
+
 void OmxScreensaver::resetCounter()
 {
 	screenSaverCounter = 0;
 }
+
 void OmxScreensaver::updateLEDs()
 {
 	unsigned long playstepmillis = millis();

--- a/OMX-27-firmware/src/modes/omx_screensaver.h
+++ b/OMX-27-firmware/src/modes/omx_screensaver.h
@@ -30,10 +30,9 @@ public:
 private:
 	void setScreenSaverColor();
 	elapsedMillis screenSaverCounter = 0;
-	unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default? // 10000;  15000; //
+	unsigned long screensaverInterval = 1000 * 60 * 3; // 3 minutes default
+	uint32_t ssMaxColorDepth = 65528; // used by setScreenSaverColor(). Allows for full rainbow of colors, plus a little extra for 'black'
 
-	// Uncomment for 10 second screensaver for testing
-	// unsigned long screensaverInterval = 1000 * 10;
 	int ssstep = 0;
 	int ssloop = 0;
 	volatile unsigned long nextStepTimeSS = 0;


### PR DESCRIPTION
The screensaver was only using half of the rainbow of colors.  This fix enables the full range of colors, plus `black` if the potentiometer is turned fully clockwise, allowing the screensaver to effectively be turned off if desired.

This pull request includes several changes to the `OMX-27-firmware` project, focusing on improving the screensaver functionality and fixing a minor issue with potentiometer value ranges. The most important changes include updating the potentiometer maximum values, refining the screensaver color setting logic, and adding a new configuration parameter for color depth.

### Potentiometer Value Range Fix:
* [`OMX-27-firmware/src/config.cpp`](diffhunk://#diff-4e9f45719e4a0918bd5eeab80a6d0aa4b5c5f86996f69693d2cef8736199a0c1L58-R60): Corrected the maximum potentiometer value for T3.2 from 8190 to 8191.  This corrected the `map` function that sets the color according to the potentiometer value.

### Screensaver Functionality Enhancements:
* [`OMX-27-firmware/src/modes/omx_screensaver.cpp`](diffhunk://#diff-f631d0c09ae73aef669b95dce61d47dfe7918ae82d19390adc14fd4d03aae4acL10-R19): Modified the `setScreenSaverColor` method to use a new `ssMaxColorDepth` parameter instead of a hardcoded value. [[1]](diffhunk://#diff-f631d0c09ae73aef669b95dce61d47dfe7918ae82d19390adc14fd4d03aae4acL10-R19) [[2]](diffhunk://#diff-f631d0c09ae73aef669b95dce61d47dfe7918ae82d19390adc14fd4d03aae4acL84-R91)
* [`OMX-27-firmware/src/modes/omx_screensaver.cpp`](diffhunk://#diff-f631d0c09ae73aef669b95dce61d47dfe7918ae82d19390adc14fd4d03aae4acL10-R19): Added a check to update the screensaver color only if the relevant potentiometer has changed.
* [`OMX-27-firmware/src/modes/omx_screensaver.cpp`](diffhunk://#diff-f631d0c09ae73aef669b95dce61d47dfe7918ae82d19390adc14fd4d03aae4acR30-R35): Updated the `updateScreenSaverState` method to set the screensaver color when the screensaver becomes active.
* [`OMX-27-firmware/src/modes/omx_screensaver.h`](diffhunk://#diff-341b7d3c81ffa72769c18aa2663aa52e9745728e48252c8c13047f5718d1be5fL33-L36): Introduced a new `ssMaxColorDepth` parameter for better color configuration.