### PR TITLE
AUX pot-bank controls on keys 13–14 (Keys, Drums, Chords)

### DIFF
--- a/OMX-27-firmware/src/config.h
+++ b/OMX-27-firmware/src/config.h
@@ -16,10 +16,10 @@
 // #include <cstdarg>
 
 /* * firmware metadata  */
-// OMX_VERSION = 1.14.1
+// OMX_VERSION = 1.15.0
 const int MAJOR_VERSION = 1;
-const int MINOR_VERSION = 14;
-const int POINT_VERSION = 1;
+const int MINOR_VERSION = 15;
+const int POINT_VERSION = 0;
 
 // 1.13.2 - Adds CV Trigger modes for legato and regtrig
 // 1.13.3 - Bugfix for CV Trigger modes

--- a/OMX-27-firmware/src/modes/omx_mode_chords.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_chords.cpp
@@ -3,6 +3,7 @@
 #include "../globals.h"
 #include "../consts/colors.h"
 #include "../utils/omx_util.h"
+#include "../utils/pot_bank_aux.h"
 #include "../utils/cvNote_util.h"
 #include "../hardware/omx_disp.h"
 #include "../hardware/omx_leds.h"
@@ -1094,6 +1095,7 @@ void OmxModeChords::onKeyUpdate(OMXKeypadEvent e)
 		{
 			auxDown_ = false;
 			midiSettings.midiAUX = false;
+			potBankAuxClearFlash();
 
 			// Forces all arps to work.
 			for (uint8_t i = 0; i < NUM_MIDIFX_GROUPS; i++)
@@ -1114,6 +1116,22 @@ void OmxModeChords::onKeyUpdate(OMXKeypadEvent e)
 			{
 				int amt = thisKey == 11 ? -1 : 1;
 				midiSettings.octave = constrain(midiSettings.octave + amt, -5, 4);
+			}
+			else if (thisKey == 13 || thisKey == 14)
+			{
+				const int n = NUM_CC_BANKS;
+				int b = potSettings.potbank;
+				if (thisKey == 13)
+				{
+					b = (b + n - 1) % n;
+				}
+				else
+				{
+					b = (b + 1) % n;
+				}
+				potSettings.potbank = b;
+				potBankAuxTriggerFlash((uint8_t)b);
+				MM::sendControlChange(90, potSettings.potbank, sysSettings.midiChannel);
 			}
 			else if (!mfxQuickEdit_ && (thisKey == 1 || thisKey == 2)) // Change Param selection
 			{
@@ -2229,6 +2247,24 @@ void OmxModeChords::updateLEDs()
 		{
 			strip.setPixelColor(25, colorConfig.arpHoldOff);
 			strip.setPixelColor(26, colorConfig.arpOff);
+		}
+
+		{
+			uint32_t fc;
+			bool lit;
+			if (potBankAuxPollFlash(&fc, &lit))
+			{
+				strip.setPixelColor(13, lit ? fc : LEDOFF);
+				strip.setPixelColor(14, lit ? fc : LEDOFF);
+			}
+			else
+			{
+				uint32_t c13;
+				uint32_t c14;
+				potBankAuxPreviewColors((uint8_t)potSettings.potbank, &c13, &c14);
+				strip.setPixelColor(13, c13);
+				strip.setPixelColor(14, c14);
+			}
 		}
 
 		return;

--- a/OMX-27-firmware/src/modes/omx_mode_drum.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_drum.cpp
@@ -7,6 +7,7 @@
 #include "../hardware/omx_disp.h"
 #include "../hardware/omx_leds.h"
 #include "../midi/midi.h"
+#include "../utils/pot_bank_aux.h"
 #include "../utils/music_scales.h"
 #include "../midi/noteoffs.h"
 
@@ -593,6 +594,22 @@ void OmxModeDrum::onKeyUpdate(OMXKeypadEvent e)
 
 					omxDisp.displayMessage("Loaded " + String(newKitIndex + 1));
 				}
+				else if (thisKey == 13 || thisKey == 14)
+				{
+					const int n = NUM_CC_BANKS;
+					int b = potSettings.potbank;
+					if (thisKey == 13)
+					{
+						b = (b + n - 1) % n;
+					}
+					else
+					{
+						b = (b + 1) % n;
+					}
+					potSettings.potbank = b;
+					potBankAuxTriggerFlash((uint8_t)b);
+					MM::sendControlChange(90, potSettings.potbank, sysSettings.midiChannel);
+				}
 			}
 
 			if (!keyConsumed)
@@ -619,6 +636,7 @@ void OmxModeDrum::onKeyUpdate(OMXKeypadEvent e)
 		if (midiSettings.midiAUX)
 		{
 			midiSettings.midiAUX = false;
+			potBankAuxClearFlash();
 		}
 	}
 
@@ -906,6 +924,24 @@ void OmxModeDrum::updateLEDs()
 		{
 			strip.setPixelColor(25, colorConfig.arpHoldOff);
 			strip.setPixelColor(26, colorConfig.arpOff);
+		}
+
+		{
+			uint32_t fc;
+			bool lit;
+			if (potBankAuxPollFlash(&fc, &lit))
+			{
+				strip.setPixelColor(13, lit ? fc : LEDOFF);
+				strip.setPixelColor(14, lit ? fc : LEDOFF);
+			}
+			else
+			{
+				uint32_t c13;
+				uint32_t c14;
+				potBankAuxPreviewColors((uint8_t)potSettings.potbank, &c13, &c14);
+				strip.setPixelColor(13, c13);
+				strip.setPixelColor(14, c14);
+			}
 		}
 	}
 	else

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
@@ -7,6 +7,7 @@
 #include "../hardware/omx_disp.h"
 #include "../hardware/omx_leds.h"
 #include "../midi/midi.h"
+#include "../utils/pot_bank_aux.h"
 #include "../utils/music_scales.h"
 #include "../midi/noteoffs.h"
 #include "sequencer.h"
@@ -683,6 +684,22 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 					int amt = thisKey == 11 ? -1 : 1;
 					midiSettings.octave = constrain(midiSettings.octave + amt, -5, 4);
 				}
+				else if (thisKey == 13 || thisKey == 14) // Pot bank (wrapped)
+				{
+					const int n = NUM_CC_BANKS;
+					int b = potSettings.potbank;
+					if (thisKey == 13)
+					{
+						b = (b + n - 1) % n;
+					}
+					else
+					{
+						b = (b + 1) % n;
+					}
+					potSettings.potbank = b;
+					potBankAuxTriggerFlash((uint8_t)b);
+					MM::sendControlChange(90, potSettings.potbank, sysSettings.midiChannel);
+				}
 				else if (!mfxQuickEdit_ && (thisKey == 1 || thisKey == 2)) // Change Param selection
 				{
 					if (thisKey == 1)
@@ -808,12 +825,15 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 		{
 			midiSettings.midiAUX = false;
 		}
+		potBankAuxClearFlash();
 		// turn off leds
 		strip.setPixelColor(0, LEDOFF);
 		strip.setPixelColor(1, LEDOFF);
 		strip.setPixelColor(2, LEDOFF);
 		strip.setPixelColor(11, LEDOFF);
 		strip.setPixelColor(12, LEDOFF);
+		strip.setPixelColor(13, LEDOFF);
+		strip.setPixelColor(14, LEDOFF);
 	}
 
 	omxLeds.setDirty();
@@ -1114,6 +1134,24 @@ void OmxModeMidiKeyboard::updateLEDs()
 		{
 			strip.setPixelColor(25, colorConfig.arpHoldOff);
 			strip.setPixelColor(26, colorConfig.arpOff);
+		}
+
+		{
+			uint32_t fc;
+			bool lit;
+			if (potBankAuxPollFlash(&fc, &lit))
+			{
+				strip.setPixelColor(13, lit ? fc : LEDOFF);
+				strip.setPixelColor(14, lit ? fc : LEDOFF);
+			}
+			else
+			{
+				uint32_t c13;
+				uint32_t c14;
+				potBankAuxPreviewColors((uint8_t)potSettings.potbank, &c13, &c14);
+				strip.setPixelColor(13, c13);
+				strip.setPixelColor(14, c14);
+			}
 		}
 
 		// strip.setPixelColor(10, color3); // MidiFX key

--- a/OMX-27-firmware/src/utils/pot_bank_aux.cpp
+++ b/OMX-27-firmware/src/utils/pot_bank_aux.cpp
@@ -1,0 +1,71 @@
+#include "pot_bank_aux.h"
+
+#include "../consts/colors.h"
+
+#include <elapsedMillis.h>
+
+namespace
+{
+	const uint32_t kBankColors[NUM_CC_BANKS] = {RED, YELLOW, WHITE, CYAN, BLUE};
+
+	elapsedMillis flashElapsed;
+	uint8_t flashBankIdx = 0;
+	uint8_t flashPhase = 0;
+	const uint8_t kFlashPhases = 6;
+	bool flashActive = false;
+}
+
+uint32_t potBankAuxColor(uint8_t bankIndex)
+{
+	return kBankColors[bankIndex % NUM_CC_BANKS];
+}
+
+void potBankAuxPreviewColors(uint8_t currentBank, uint32_t *out13, uint32_t *out14)
+{
+	const uint8_t b = currentBank % NUM_CC_BANKS;
+	*out13 = kBankColors[(b + NUM_CC_BANKS - 1) % NUM_CC_BANKS];
+	*out14 = kBankColors[(b + 1) % NUM_CC_BANKS];
+}
+
+void potBankAuxTriggerFlash(uint8_t newBankIndex)
+{
+	flashBankIdx = newBankIndex % NUM_CC_BANKS;
+	flashPhase = 0;
+	flashActive = true;
+	flashElapsed = 0;
+}
+
+void potBankAuxClearFlash()
+{
+	flashActive = false;
+	flashPhase = 0;
+}
+
+bool potBankAuxPollFlash(uint32_t *outColor, bool *ledsLit)
+{
+	if (!flashActive || outColor == nullptr || ledsLit == nullptr)
+	{
+		return false;
+	}
+
+	if (flashPhase >= kFlashPhases)
+	{
+		flashActive = false;
+		return false;
+	}
+
+	if (flashElapsed >= 70)
+	{
+		flashElapsed = 0;
+		flashPhase++;
+		if (flashPhase >= kFlashPhases)
+		{
+			flashActive = false;
+			return false;
+		}
+	}
+
+	*ledsLit = (flashPhase % 2) == 0;
+	*outColor = potBankAuxColor(flashBankIdx);
+	return true;
+}

--- a/OMX-27-firmware/src/utils/pot_bank_aux.h
+++ b/OMX-27-firmware/src/utils/pot_bank_aux.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "../config.h"
+
+uint32_t potBankAuxColor(uint8_t bankIndex);
+
+void potBankAuxPreviewColors(uint8_t currentBank, uint32_t *out13, uint32_t *out14);
+
+void potBankAuxTriggerFlash(uint8_t newBankIndex);
+
+void potBankAuxClearFlash();
+
+// Call from updateLEDs while AUX bank UI active. If returns true, set LEDs 13&14 to color (or LEDOFF when false).
+bool potBankAuxPollFlash(uint32_t *outColor, bool *ledsLit);


### PR DESCRIPTION
TL;DR: Allows the user to switch pot banks quickly while holding AUX, similar to octave switching.

While AUX is active, keys 13/14 step potSettings.potbank with wrap, mirror CC 90 like the Pots page encoder path, and drive LEDs 13/14 with preview or flash. Clear flash and LED state on AUX release where needed.

Bank colors (0-based bank index): 0 red, 1 yellow, 2 white, 3 cyan, 4 blue.