### PR TITLE
AUX transport controls, Pot Config CC editing, v1.15.0 (EEPROM v39)

### DIFF
--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -1,6 +1,6 @@
 // OMX-27 MIDI KEYBOARD / SEQUENCER
 
-//	v1.14.1
+//	v1.15.0
 //	Last update: April 2026
 //
 //	Original concept and initial code by Steven Noreyko
@@ -346,7 +346,11 @@ void saveHeader()
 
 	storage->write(EEPROM_HEADER_ADDRESS + 38, potSettings.potbank);
 
-	// 38 bytes
+	storage->write(EEPROM_HEADER_ADDRESS + 39, midiSettings.transportCC[0]);
+	storage->write(EEPROM_HEADER_ADDRESS + 40, midiSettings.transportCC[1]);
+	storage->write(EEPROM_HEADER_ADDRESS + 41, midiSettings.transportCC[2]);
+
+	// 42 bytes
 }
 
 // returns true if the header contained initialized data
@@ -419,6 +423,10 @@ bool loadHeader(void)
 	cvNoteUtil.triggerMode = constrain(storage->read(EEPROM_HEADER_ADDRESS + 37), 0, 1);
 
 	potSettings.potbank = constrain(storage->read(EEPROM_HEADER_ADDRESS + 38), 0, NUM_CC_BANKS-1);
+
+	midiSettings.transportCC[0] = constrain(storage->read(EEPROM_HEADER_ADDRESS + 39), 0, 127);
+	midiSettings.transportCC[1] = constrain(storage->read(EEPROM_HEADER_ADDRESS + 40), 0, 127);
+	midiSettings.transportCC[2] = constrain(storage->read(EEPROM_HEADER_ADDRESS + 41), 0, 127);
 
 	// digitalWrite(BLUELED, HIGH);
 	return true;
@@ -1096,6 +1104,10 @@ void setup()
 		pots[0][2] = CC3;
 		pots[0][3] = CC4;
 		pots[0][4] = CC5;
+
+		midiSettings.transportCC[0] = 102;
+		midiSettings.transportCC[1] = 103;
+		midiSettings.transportCC[2] = 104;
 
 		omxModeSeq.initPatterns();
 

--- a/OMX-27-firmware/src/config.cpp
+++ b/OMX-27-firmware/src/config.cpp
@@ -2,7 +2,7 @@
 #include "consts/consts.h"
 
 const OMXMode DEFAULT_MODE = MODE_MIDI;
-const uint8_t EEPROM_VERSION = 38;
+const uint8_t EEPROM_VERSION = 39;
 
 // v30 - adds storage to header for velocity
 // v31 - adds storage for drums
@@ -11,6 +11,7 @@ const uint8_t EEPROM_VERSION = 38;
 // v34 - adds mfx repeat saves
 // v35 - adds quantize rate to arps, added global quant rate to header
 // v36 - adds stuff to randomizer
+// v39 - transport CC assignments (AUX keys 16–18): three bytes after header
 
 // DEFINE CC NUMBERS FOR POTS // CCS mapped to Organelle Defaults
 const int CC1 = 21;
@@ -57,12 +58,13 @@ const int LED_COUNT = 27;
 
 const int potCount = NUM_CC_POTS;
 
+// Banks 2–5 avoid CC 102–119 (default transport / general MIDI undefined range)
 int pots[NUM_CC_BANKS][NUM_CC_POTS] = {
 	{CC1, CC2, CC3, CC4, CC5},
-	{29, 30, 31, 32, 33},
-	{34, 35, 36, 37, 38},
-	{39, 40, 41, 42, 43},
-	{91, 93, 103, 104, 7}}; // the MIDI CC (continuous controller) for each analog input
+	{25, 26, 27, 28, CC5},
+	{46, 47, 48, 49, CC5},
+	{50, 51, 52, 53, CC5},
+	{54, 55, 56, 57, CC5}}; // the MIDI CC (continuous controller) for each analog input
 
 int potMinVal = 0;
 #if BOARDTYPE == TEENSY4

--- a/OMX-27-firmware/src/config.h
+++ b/OMX-27-firmware/src/config.h
@@ -182,6 +182,13 @@ struct MidiConfig
 	// AUX transport (keys 16–18): configurable CCs; Stop = momentary, Play/Rec = toggles (879eccc semantics).
 	uint8_t transportCC[3] = {102, 103, 104};
 	bool transportToggle[3] = {false, false, false};
+
+	// MIDI mode AUX controls in Keys mode.
+	uint8_t metronomeToggleCC = 105; // key 15 toggle (0/127)
+	uint8_t countInCC = 106;         // key 4 cycle (0/1/2/4)
+	uint8_t metronomePulseCC = 107; // inbound DAW metronome pulse (0-127 brightness)
+	uint8_t metronomePulseHostCC = 108; // key 3: host sends metronome pulses to OMX (0/127)
+	uint16_t metronomeColorHue = 10922; // default yellow in NeoPixel HSV space
 };
 
 extern MidiConfig midiSettings;

--- a/OMX-27-firmware/src/config.h
+++ b/OMX-27-firmware/src/config.h
@@ -29,6 +29,7 @@ const int POINT_VERSION = 0;
 // 1.13.3 - Bugfix for CV Trigger modes
 // 1.13.8 - option to send midi all the time or not
 // 1.14.0 - finish RP2040 port
+// 1.15.0 - AUX transport (keys 16–18), Pot Config CCs, EEPROM v39
 
 const int DEVICE_ID = 2;
 
@@ -177,6 +178,10 @@ struct MidiConfig
 	bool midiSoftThru = false;
 	bool midiAUX = false;
 	bool isBankSelect = false;
+
+	// AUX transport (keys 16–18): configurable CCs; Stop = momentary, Play/Rec = toggles (879eccc semantics).
+	uint8_t transportCC[3] = {102, 103, 104};
+	bool transportToggle[3] = {false, false, false};
 };
 
 extern MidiConfig midiSettings;

--- a/OMX-27-firmware/src/consts/colors.h
+++ b/OMX-27-firmware/src/consts/colors.h
@@ -68,6 +68,11 @@ const auto LOWWHITE = 0x202020;
 const auto VLOWWHITE = 0x101010;
 const auto LEDOFF = 0x000000;
 
+// AUX transport keys (Stop/Play/Rec) when off — dim so full brightness reads clearly when on
+const auto TRANSPORT_DIM_WHITE = 0x060606;
+const auto TRANSPORT_DIM_RED = 0x0C0000;
+const auto TRANSPORT_DIM_GREEN = 0x000C00;
+
 // sequencer pattern colors
 const uint32_t seqColors[] = {ORANGE, YELLOW, GREEN, MAGENTA, CYAN, BLUE, LIME, LTPURPLE};
 const uint32_t muteColors[] = {DKORANGE, DKYELLOW, DKGREEN, DKMAGENTA, DKCYAN, DKBLUE, DKLIME, DKPURPLE};

--- a/OMX-27-firmware/src/midi/midi.cpp
+++ b/OMX-27-firmware/src/midi/midi.cpp
@@ -130,6 +130,7 @@ namespace MM
 		}
 
 		// sendControlChange(control, value, channel);
+		activeOmxMode->inMidiControlChange(channel, control, value);
 	}
 
 	// absolute_time_t last_ext_tick_at_ = 0;

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
@@ -1401,6 +1401,26 @@ void OmxModeMidiKeyboard::inMidiNoteOff(byte channel, byte note, byte velocity)
 
 void OmxModeMidiKeyboard::inMidiControlChange(byte channel, byte control, byte value)
 {
+	if (control == midiSettings.transportCC[0])
+	{
+		// Stop is treated as a momentary event; clear play state on non-zero values.
+		if (value > 0)
+		{
+			midiSettings.transportToggle[1] = false;
+			omxLeds.setDirty();
+		}
+	}
+	else if (control == midiSettings.transportCC[1])
+	{
+		midiSettings.transportToggle[1] = value >= 64;
+		omxLeds.setDirty();
+	}
+	else if (control == midiSettings.transportCC[2])
+	{
+		midiSettings.transportToggle[2] = value >= 64;
+		omxLeds.setDirty();
+	}
+
 	auto activeMacro = getActiveMacro();
 
 	if (activeMacro != nullptr)

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
@@ -700,6 +700,24 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 					potBankAuxTriggerFlash((uint8_t)b);
 					MM::sendControlChange(90, potSettings.potbank, sysSettings.midiChannel);
 				}
+				else if (thisKey >= 16 && thisKey <= 18) // Transport: 16=Stop (momentary), 17/18=Play/Rec (toggle)
+				{
+					int transportIndex = thisKey - 16;
+					uint8_t cc = (uint8_t)constrain(midiSettings.transportCC[transportIndex], 0, 127);
+					uint8_t val;
+					if (transportIndex == 0)
+					{
+						val = 127;
+						midiSettings.transportToggle[1] = false;
+					}
+					else
+					{
+						bool newState = !midiSettings.transportToggle[transportIndex];
+						midiSettings.transportToggle[transportIndex] = newState;
+						val = newState ? 127 : 0;
+					}
+					MM::sendControlChange(cc, val, sysSettings.midiChannel);
+				}
 				else if (!mfxQuickEdit_ && (thisKey == 1 || thisKey == 2)) // Change Param selection
 				{
 					if (thisKey == 1)
@@ -786,7 +804,15 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 		}
 		else if (!e.down() && thisKey != 0)
 		{
-			doNoteOff(thisKey);
+			if (midiSettings.midiAUX && thisKey == 16)
+			{
+				uint8_t cc = (uint8_t)constrain(midiSettings.transportCC[0], 0, 127);
+				MM::sendControlChange(cc, 0, sysSettings.midiChannel);
+			}
+			if (!(midiSettings.midiAUX && thisKey >= 16 && thisKey <= 18))
+			{
+				doNoteOff(thisKey);
+			}
 			// omxUtil.midiNoteOff(thisKey, sysSettings.midiChannel);
 		}
 	}
@@ -834,6 +860,9 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 		strip.setPixelColor(12, LEDOFF);
 		strip.setPixelColor(13, LEDOFF);
 		strip.setPixelColor(14, LEDOFF);
+		strip.setPixelColor(16, LEDOFF);
+		strip.setPixelColor(17, LEDOFF);
+		strip.setPixelColor(18, LEDOFF);
 	}
 
 	omxLeds.setDirty();
@@ -1153,6 +1182,9 @@ void OmxModeMidiKeyboard::updateLEDs()
 				strip.setPixelColor(14, c14);
 			}
 		}
+		strip.setPixelColor(16, midiSettings.keyState[16] ? WHITE : TRANSPORT_DIM_WHITE);
+		strip.setPixelColor(17, midiSettings.transportToggle[1] ? GREEN : TRANSPORT_DIM_GREEN);
+		strip.setPixelColor(18, midiSettings.transportToggle[2] ? RED : TRANSPORT_DIM_RED);
 
 		// strip.setPixelColor(10, color3); // MidiFX key
 

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.cpp
@@ -29,6 +29,49 @@ enum MIKeyModePage {
 	MIPAGE_VERSION
 };
 
+namespace
+{
+uint8_t nextCountInValue(uint8_t current)
+{
+	switch (current)
+	{
+	case 0:
+		return 1;
+	case 1:
+		return 2;
+	case 2:
+		return 4;
+	default:
+		return 0;
+	}
+}
+
+uint8_t normalizeCountInValue(uint8_t value)
+{
+	switch (value)
+	{
+	case 0:
+	case 1:
+	case 2:
+	case 4:
+		return value;
+	default:
+		if (value >= 4)
+			return 4;
+		if (value >= 2)
+			return 2;
+		if (value >= 1)
+			return 1;
+		return 0;
+	}
+}
+
+uint32_t getMetronomeColor(uint8_t brightness = 255)
+{
+	return strip.ColorHSV(midiSettings.metronomeColorHue, 255, brightness);
+}
+}
+
 OmxModeMidiKeyboard::OmxModeMidiKeyboard()
 {
 	// Add 4 pages
@@ -211,6 +254,7 @@ void OmxModeMidiKeyboard::onClockTick()
 
 void OmxModeMidiKeyboard::loopUpdate(Micros elapsedTime)
 {
+	(void)elapsedTime;
 
 	// if (elapsedTime > 0)
 	// {
@@ -229,6 +273,12 @@ void OmxModeMidiKeyboard::loopUpdate(Micros elapsedTime)
 
 	// Can be modified by scale MidiFX
 	musicScale->calculateScaleIfModified(scaleConfig.scaleRoot, scaleConfig.scalePattern);
+
+	if (metronomePulseLevel_ > 0 && (int32_t)(millis() - metronomePulseOffAtMs_) >= 0)
+	{
+		metronomePulseLevel_ = 0;
+		omxLeds.setDirty();
+	}
 
 	// if (isSubmodeEnabled())
 	// {
@@ -279,6 +329,23 @@ void OmxModeMidiKeyboard::onEncoderChanged(Encoder::Update enc)
 		// onEncoderChangedSelectParam(enc);
 		params.changeParam(enc.dir());
 		omxDisp.setDirty();
+		return;
+	}
+
+	// While AUX is held, key 3 + encoder edits metronome hue.
+	if (midiSettings.midiAUX && midiSettings.keyState[3])
+	{
+		int amt = enc.accel(8);
+		if (amt != 0)
+		{
+			metronomeColorAdjustedWhileHeld_ = true;
+			int32_t hue = (int32_t)midiSettings.metronomeColorHue + (amt * 256);
+			while (hue < 0)
+				hue += 65536;
+			midiSettings.metronomeColorHue = (uint16_t)(hue % 65536);
+			omxLeds.setDirty();
+			omxDisp.setDirty();
+		}
 		return;
 	}
 
@@ -718,6 +785,22 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 					}
 					MM::sendControlChange(cc, val, sysSettings.midiChannel);
 				}
+				else if (thisKey == 15) // Metronome toggle
+				{
+					metronomeEnabled_ = !metronomeEnabled_;
+					MM::sendControlChange(midiSettings.metronomeToggleCC, metronomeEnabled_ ? 127 : 0, sysSettings.midiChannel);
+				}
+				else if (thisKey == 3) // Host sends metronome pulse CC to OMX (toggle)
+				{
+					// Toggle is handled on key release so hold+encoder can edit color without toggling.
+					metronomePulseTogglePending_ = true;
+					metronomeColorAdjustedWhileHeld_ = false;
+				}
+				else if (thisKey == 4) // Count-in cycle: 0, 1, 2, 4
+				{
+					countInBars_ = nextCountInValue(countInBars_);
+					MM::sendControlChange(midiSettings.countInCC, countInBars_, sysSettings.midiChannel);
+				}
 				else if (!mfxQuickEdit_ && (thisKey == 1 || thisKey == 2)) // Change Param selection
 				{
 					if (thisKey == 1)
@@ -809,7 +892,20 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 				uint8_t cc = (uint8_t)constrain(midiSettings.transportCC[0], 0, 127);
 				MM::sendControlChange(cc, 0, sysSettings.midiChannel);
 			}
-			if (!(midiSettings.midiAUX && thisKey >= 16 && thisKey <= 18))
+			if (midiSettings.midiAUX && thisKey == 3)
+			{
+				if (metronomePulseTogglePending_ && !metronomeColorAdjustedWhileHeld_)
+				{
+					metronomePulseFromHostEnabled_ = !metronomePulseFromHostEnabled_;
+					MM::sendControlChange(
+						midiSettings.metronomePulseHostCC,
+						metronomePulseFromHostEnabled_ ? 127 : 0,
+						sysSettings.midiChannel);
+				}
+				metronomePulseTogglePending_ = false;
+				metronomeColorAdjustedWhileHeld_ = false;
+			}
+			if (!(midiSettings.midiAUX && (thisKey >= 16 && thisKey <= 18 || thisKey == 3)))
 			{
 				doNoteOff(thisKey);
 			}
@@ -852,6 +948,8 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 			midiSettings.midiAUX = false;
 		}
 		potBankAuxClearFlash();
+		metronomePulseTogglePending_ = false;
+		metronomeColorAdjustedWhileHeld_ = false;
 		// turn off leds
 		strip.setPixelColor(0, LEDOFF);
 		strip.setPixelColor(1, LEDOFF);
@@ -863,6 +961,9 @@ void OmxModeMidiKeyboard::onKeyUpdate(OMXKeypadEvent e)
 		strip.setPixelColor(16, LEDOFF);
 		strip.setPixelColor(17, LEDOFF);
 		strip.setPixelColor(18, LEDOFF);
+		strip.setPixelColor(3, LEDOFF);
+		strip.setPixelColor(4, LEDOFF);
+		strip.setPixelColor(15, LEDOFF);
 	}
 
 	omxLeds.setDirty();
@@ -1185,6 +1286,16 @@ void OmxModeMidiKeyboard::updateLEDs()
 		strip.setPixelColor(16, midiSettings.keyState[16] ? WHITE : TRANSPORT_DIM_WHITE);
 		strip.setPixelColor(17, midiSettings.transportToggle[1] ? GREEN : TRANSPORT_DIM_GREEN);
 		strip.setPixelColor(18, midiSettings.transportToggle[2] ? RED : TRANSPORT_DIM_RED);
+		strip.setPixelColor(15, metronomeEnabled_ ? YELLOW : LEDOFF);
+		if (midiSettings.keyState[3])
+		{
+			strip.setPixelColor(3, getMetronomeColor());
+		}
+		else
+		{
+			strip.setPixelColor(3, metronomePulseFromHostEnabled_ ? getMetronomeColor() : LEDOFF);
+		}
+		strip.setPixelColor(4, (countInBars_ > 0 && omxLeds.getBlinkPattern(countInBars_)) ? YELLOW : LEDOFF);
 
 		// strip.setPixelColor(10, color3); // MidiFX key
 
@@ -1201,6 +1312,12 @@ void OmxModeMidiKeyboard::updateLEDs()
 
 		auto auxColor = (blinkStateSlow ? RED : LEDOFF);
 		strip.setPixelColor(0, auxColor);
+	}
+
+	if (metronomePulseLevel_ > 0)
+	{
+		uint8_t brightness = (uint16_t)metronomePulseLevel_ * 255 / 127;
+		strip.setPixelColor(0, getMetronomeColor(brightness));
 	}
 }
 
@@ -1401,6 +1518,8 @@ void OmxModeMidiKeyboard::inMidiNoteOff(byte channel, byte note, byte velocity)
 
 void OmxModeMidiKeyboard::inMidiControlChange(byte channel, byte control, byte value)
 {
+	(void)channel;
+
 	if (control == midiSettings.transportCC[0])
 	{
 		// Stop is treated as a momentary event; clear play state on non-zero values.
@@ -1418,6 +1537,35 @@ void OmxModeMidiKeyboard::inMidiControlChange(byte channel, byte control, byte v
 	else if (control == midiSettings.transportCC[2])
 	{
 		midiSettings.transportToggle[2] = value >= 64;
+		omxLeds.setDirty();
+	}
+	else if (control == midiSettings.metronomeToggleCC)
+	{
+		bool newState = value >= 64;
+		if (newState != metronomeEnabled_)
+		{
+			metronomeEnabled_ = newState;
+			omxLeds.setDirty();
+		}
+	}
+	else if (control == midiSettings.countInCC)
+	{
+		countInBars_ = normalizeCountInValue(value);
+		omxLeds.setDirty();
+	}
+	else if (control == midiSettings.metronomePulseHostCC)
+	{
+		bool newState = value >= 64;
+		if (newState != metronomePulseFromHostEnabled_)
+		{
+			metronomePulseFromHostEnabled_ = newState;
+			omxLeds.setDirty();
+		}
+	}
+	else if (control == midiSettings.metronomePulseCC)
+	{
+		metronomePulseLevel_ = value;
+		metronomePulseOffAtMs_ = millis() + 90;
 		omxLeds.setDirty();
 	}
 

--- a/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.h
+++ b/OMX-27-firmware/src/modes/omx_mode_midi_keyboard.h
@@ -121,6 +121,13 @@ private:
 
 	uint8_t mfxIndex_ = 0;
 	uint8_t quickEditMfxIndex_ = 0;
+	bool metronomeEnabled_ = false;
+	bool metronomePulseFromHostEnabled_ = true; // Bitwig sends CC107 pulses when true
+	bool metronomePulseTogglePending_ = false;
+	bool metronomeColorAdjustedWhileHeld_ = false;
+	uint8_t countInBars_ = 0; // 0,1,2,4
+	uint8_t metronomePulseLevel_ = 0;
+	uint32_t metronomePulseOffAtMs_ = 0;
 
 	midimacro::MidiMacroNorns nornsMarco_;
 	midimacro::MidiMacroM8 m8Macro_;

--- a/OMX-27-firmware/src/modes/submodes/submode_potconfig.cpp
+++ b/OMX-27-firmware/src/modes/submodes/submode_potconfig.cpp
@@ -1,5 +1,6 @@
 
 #include "../../globals.h"
+#include "../../config.h"
 #include "submode_potconfig.h"
 #include "../../hardware/omx_disp.h"
 #include "../../hardware/omx_leds.h"
@@ -16,7 +17,7 @@ SubModePotConfig::SubModePotConfig()
 {
 	params_.addPage(4);
 	params_.addPage(4);
-	params_.addPage(1); // Exit submode
+	params_.addPage(4); // Stop / Play / Rec CC + Exit
 }
 
 void SubModePotConfig::onEnabled()
@@ -125,6 +126,14 @@ void SubModePotConfig::onEncoderChangedEditParam(Encoder::Update enc)
 			potSettings.potbank = constrain(potSettings.potbank + amt, 0, NUM_CC_BANKS - 1);
 		}
 	}
+	else if (selPage == POTPAGE_EXIT)
+	{
+		if (selParam >= 1 && selParam <= 3)
+		{
+			int ti = selParam - 1;
+			midiSettings.transportCC[ti] = (uint8_t)constrain((int)midiSettings.transportCC[ti] + amt, 0, 127);
+		}
+	}
 
 	omxDisp.setDirty();
 	omxLeds.setDirty();
@@ -132,7 +141,7 @@ void SubModePotConfig::onEncoderChangedEditParam(Encoder::Update enc)
 
 void SubModePotConfig::onEncoderButtonDown()
 {
-	if (params_.getSelPage() == POTPAGE_EXIT && params_.getSelParam() == 0)
+	if (params_.getSelPage() == POTPAGE_EXIT && params_.getSelParam() == 3)
 	{
 		setEnabled(false);
 	}
@@ -227,18 +236,18 @@ void SubModePotConfig::setupPageLegends()
 	break;
 	case POTPAGE_EXIT:
 	{
-		omxDisp.legends[0] = "Exit";
-		omxDisp.legends[1] = "";
-		omxDisp.legends[2] = "";
-		omxDisp.legends[3] = "";
-		omxDisp.legendVals[0] = -127;
-		omxDisp.legendVals[1] = -127;
-		omxDisp.legendVals[2] = -127;
+		omxDisp.legends[0] = "Stop";
+		omxDisp.legends[1] = "Play";
+		omxDisp.legends[2] = "Rec";
+		omxDisp.legends[3] = "Exit";
+		omxDisp.legendVals[0] = midiSettings.transportCC[0];
+		omxDisp.legendVals[1] = midiSettings.transportCC[1];
+		omxDisp.legendVals[2] = midiSettings.transportCC[2];
 		omxDisp.legendVals[3] = -127;
-		omxDisp.legendText[0] = "Exit";
+		omxDisp.legendText[0] = "";
 		omxDisp.legendText[1] = "";
 		omxDisp.legendText[2] = "";
-		omxDisp.legendText[3] = "";
+		omxDisp.legendText[3] = "Exit";
 	}
 	break;
 	default:


### PR DESCRIPTION
TL;DR - Adds simple (configurable) transport controls to AUX.

MIDI Keys — AUX transport (keys 16–18)

Stop (16): momentary: send configured CC at 127 on press, 0 on release; clears Play latch (no Play CC sent on that clear). Play (17) / Rec (18): toggle 0 / 127 on each press; state kept in midiSettings.transportToggle[1] and [2]. LEDs: white / green / red vs dim off-colors (TRANSPORT_DIM_*); key 16 uses keyState[16] for “held”; 17–18 follow toggles. Clear 16–18 when AUX is released. Note path: do not run doNoteOff for 16–18 while AUX is on so transport keys do not trigger note-off behavior. State & persistence

MidiConfig: transportCC[3] default 102 / 103 / 104; transportToggle[3] for Play/Rec. EEPROM v39: header bytes 39–41 store the three transport CCs; saveHeader / loadHeader updated (header length 42 bytes). Cold init (failed/missing storage): set transport CCs to 102–104. Pot Config submode

Third page expanded from a single Exit row to four parameters: Stop / Play / Rec CC numbers (encoder) and Exit (encoder button on last slot). Encoder adjusts CC 0–127 for slots 1–3. Defaults

pots[][] banks 2–5: remap so factory CCs avoid 102–119 (overlap with default transport / GM undefined band); knob 5 uses CC5 (7) like bank 0 where applicable. Version

Firmware v1.15.0 (config.h + .ino header comment); changelog note for 1.15.0. BREAKING / user-visible: EEPROM version bump may invalidate existing header until a successful load/save cycle; users with old bank 5 mappings that used 103/104 should verify or re-save pot CC tables.