### PR TITLE
Updated default knob CC values

### DIFF
--- a/CC_HRCC_COMPATIBILITY_NOTE.md
+++ b/CC_HRCC_COMPATIBILITY_NOTE.md
@@ -1,0 +1,47 @@
+# OMX-27 Default Pot CC Mapping and HRCC Compatibility
+
+## Summary
+
+This note explains why changing the default knob CC assignments is recommended for DAW interoperability.
+
+The current firmware sends standard 7-bit MIDI CC messages for knob movement. However, several default CC numbers used by pot banks fall into MIDI ranges that many tools and DAWs interpret as part of 14-bit CC pairs ("high-resolution CC" / HRCC). This can cause confusing behavior in MIDI monitoring and, in some hosts, unreliable MIDI learn.
+
+## What Is Happening
+
+OMX-27 pot movement is sent as standard `Control Change` messages (single CC, 0-127), not intentional 14-bit messages.
+
+In MIDI, controllers are organized as paired ranges:
+
+- MSB controllers: `0-31`
+- LSB controllers: `32-63` (paired as `MSB + 32`)
+
+Examples of pairs:
+
+- `22` (MSB) pairs with `54` (LSB)
+- `21` (MSB) pairs with `53` (LSB)
+- `23` (MSB) pairs with `55` (LSB)
+
+Several existing OMX defaults include values in these paired ranges (for example `21-24`, `50-57`). If a monitor/host sees related values over time, it may reconstruct and display HRCC values even though OMX is only sending regular CC.
+
+## Why This Matters
+
+Depending on the DAW or MIDI middleware, paired-range CCs can lead to:
+
+- MIDI learn binding to 14-bit interpretation unexpectedly
+- Learn capturing the paired controller semantics instead of simple 7-bit CC behavior
+- Parameter jitter/jumps or confusing scaling when stale pair data is combined
+- Inconsistent behavior between DAWs (one host works fine, another is problematic)
+
+This issue appears most often in controller-mapping workflows and monitor tools that infer HRCC from CC number ranges.
+
+## Recommendation
+
+For maximum compatibility, avoid using default knob CCs in `0-63` where 14-bit pair semantics are common.
+
+A safer default strategy is to assign pot CCs in `64-95` (or another non-paired range that does not conflict with transport/meta controls).
+
+This does not remove user flexibility; users can still manually set any CC they need. The goal is simply to make out-of-box defaults more reliable across DAWs.
+
+## Important Clarification
+
+The observed HRCC readouts do not necessarily mean OMX is transmitting explicit 14-bit CC pairs by design. The behavior is primarily a compatibility/interpretation artifact of chosen CC numbers and host-side parsing.

--- a/OMX-27-firmware/OMX-27-firmware.ino
+++ b/OMX-27-firmware/OMX-27-firmware.ino
@@ -392,6 +392,51 @@ bool loadHeader(void)
 		}
 	}
 
+	// Migrate legacy default pot CC mappings to safer defaults.
+	// This is non-destructive: only rows that exactly match known legacy defaults are updated.
+	{
+		static const uint8_t kLegacyPotDefaults[NUM_CC_BANKS][NUM_CC_POTS] = {
+			{21, 22, 23, 24, 7},
+			{29, 30, 31, 32, 33},
+			{34, 35, 36, 37, 38},
+			{39, 40, 41, 42, 43},
+			{91, 93, 103, 104, 7},
+		};
+		static const uint8_t kSafePotDefaults[NUM_CC_BANKS][NUM_CC_POTS] = {
+			{110, 111, 112, 113, 7},
+			{114, 115, 116, 117, 7},
+			{118, 119, 120, 121, 7},
+			{122, 123, 124, 125, 7},
+			{126, 127, 100, 101, 7},
+		};
+
+		bool migratedAny = false;
+		for (int b = 0; b < NUM_CC_BANKS; b++)
+		{
+			bool matchesLegacy = true;
+			for (int i = 0; i < NUM_CC_POTS; i++)
+			{
+				if (pots[b][i] != kLegacyPotDefaults[b][i])
+				{
+					matchesLegacy = false;
+					break;
+				}
+			}
+
+			if (!matchesLegacy)
+				continue;
+
+			for (int i = 0; i < NUM_CC_POTS; i++)
+			{
+				pots[b][i] = kSafePotDefaults[b][i];
+				storage->write(EEPROM_HEADER_ADDRESS + 4 + i + (5 * b), pots[b][i]);
+			}
+			migratedAny = true;
+		}
+
+		(void)migratedAny;
+	}
+
 	uint8_t midiMacroChannel = storage->read(EEPROM_HEADER_ADDRESS + 29);
 	midiMacroConfig.midiMacroChan = midiMacroChannel + 1;
 

--- a/OMX-27-firmware/src/config.cpp
+++ b/OMX-27-firmware/src/config.cpp
@@ -12,11 +12,12 @@ const uint8_t EEPROM_VERSION = 38;
 // v35 - adds quantize rate to arps, added global quant rate to header
 // v36 - adds stuff to randomizer
 
-// DEFINE CC NUMBERS FOR POTS // CCS mapped to Organelle Defaults
-const int CC1 = 21;
-const int CC2 = 22;
-const int CC3 = 23;
-const int CC4 = 24;
+// DEFINE CC NUMBERS FOR POTS
+// CC1-CC4 now align with the safe default Bank 1 mapping.
+const int CC1 = 110;
+const int CC2 = 111;
+const int CC3 = 112;
+const int CC4 = 113;
 const int CC5 = 7; // change to 25 for EYESY Knob 5
 
 const int CC_AUX = 25; // Mother mode - AUX key
@@ -58,11 +59,11 @@ const int LED_COUNT = 27;
 const int potCount = NUM_CC_POTS;
 
 int pots[NUM_CC_BANKS][NUM_CC_POTS] = {
-	{CC1, CC2, CC3, CC4, CC5},
-	{29, 30, 31, 32, 33},
-	{34, 35, 36, 37, 38},
-	{39, 40, 41, 42, 43},
-	{91, 93, 103, 104, 7}}; // the MIDI CC (continuous controller) for each analog input
+	{110, 111, 112, 113, 7},
+	{114, 115, 116, 117, 7},
+	{118, 119, 120, 121, 7},
+	{122, 123, 124, 125, 7},
+	{126, 127, 100, 101, 7}}; // the MIDI CC (continuous controller) for each analog input
 
 int potMinVal = 0;
 #if BOARDTYPE == TEENSY4


### PR DESCRIPTION
See CC_HRCC_COMPATIBILITY_NOTE.md for reasoning and details.

Legacy knob bank CCs:

{21,22,23,24,7}
{29,30,31,32,33}
{34,35,36,37,38}
{39,40,41,42,43}
{91,93,103,104,7}

are now mapped to:

{110,111,112,113,7}
{114,115,116,117,7}
{118,119,120,121,7}
{122,123,124,125,7}
{126,127,100,101,7}